### PR TITLE
Add JUCE client port

### DIFF
--- a/juce_port/CMakeLists.txt
+++ b/juce_port/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.16)
+project(SanctSoundJuce VERSION 0.1 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(JUCE CONFIG REQUIRED)
+
+juce_add_gui_app(SanctSoundJuceApp
+    PRODUCT_NAME "SanctSound JUCE"
+)
+
+target_sources(SanctSoundJuceApp PRIVATE
+    Source/Main.cpp
+    Source/MainComponent.cpp
+    Source/MainComponent.h
+    Source/MetadataView.cpp
+    Source/MetadataView.h
+    Source/PreviewModels.cpp
+    Source/PreviewModels.h
+    Source/SanctSoundClient.cpp
+    Source/SanctSoundClient.h
+    Source/Utilities.cpp
+    Source/Utilities.h
+)
+
+target_compile_definitions(SanctSoundJuceApp PRIVATE
+    JUCE_MODAL_LOOPS_PERMITTED=1
+)
+
+target_link_libraries(SanctSoundJuceApp PRIVATE
+    juce::juce_gui_extra
+    juce::juce_data_structures
+    juce::juce_core
+)
+
+juce_generate_juce_header(SanctSoundJuceApp)

--- a/juce_port/README.md
+++ b/juce_port/README.md
@@ -1,0 +1,43 @@
+# SanctSound JUCE Port
+
+This directory contains a JUCE/C++ port of the original `sanctsound_gui` Tk
+application.  The port mirrors the major workflows of the Python GUI using
+native JUCE components and asynchronous tasks.  It is intended to provide a
+jumping-off point for integrating SanctSound tooling into a C++ audio workflow
+while retaining support for Google Cloud Storage, metadata preview, file
+selection, and clip generation.
+
+## Building
+
+The project is organised as a CMake build that depends on JUCE being available
+in the CMake package registry.  Configure JUCE (either via
+`cmake --install` or `FetchContent`) and then build:
+
+```bash
+cmake -B build -S juce_port -DJUCE_DIR=/path/to/juce
+cmake --build build
+```
+
+The resulting executable is `SanctSoundJuceApp`.  Run it from the root of the
+repository so that configuration files match the original Python defaults.
+
+## Features
+
+* Site selection with friendly labels and Google Cloud Storage scanning.
+* Listing detection product sets with metadata counts.
+* Embedded metadata viewer that pulls JSON summaries from GCS.
+* Preview step that downloads detection CSVs, computes run windows, and lists
+  the minimal set of audio files required for review.
+* Download and clip actions implemented with the same `gsutil` and `ffmpeg`
+  calls as the Python tooling.
+* Logging window, progress feedback, and persisted configuration.
+
+## Configuration
+
+Runtime defaults (destination directory, storage prefixes, clip format) are
+mirrored from `sanctsound_gui/config.py` in `Source/SanctSoundClient.cpp`.  Edit
+those constants as needed for your environment.
+
+The C++ port uses the same command-line utilities (`gsutil`, `ffmpeg`,
+`ffprobe`) as the original app.  Ensure they are on your `PATH` before running
+the program.

--- a/juce_port/Source/MainComponent.cpp
+++ b/juce_port/Source/MainComponent.cpp
@@ -1,0 +1,654 @@
+#include "MainComponent.h"
+
+#include <juce_gui_extra/juce_gui_extra.h>
+#include <utility>
+
+namespace sanctsound
+{
+namespace
+{
+juce::String determineMode(const juce::String& name)
+{
+    auto lower = name.toLowerCase();
+    if (lower.endsWith("_1h"))
+        return "HOUR";
+    if (lower.endsWith("_1d"))
+        return "DAY";
+    return "EVENT";
+}
+
+juce::String formatExtCounts(const ProductGroup& group)
+{
+    juce::StringArray parts;
+    for (auto& kv : group.extCounts)
+        parts.add(kv.first + ":" + juce::String(kv.second));
+    return parts.joinIntoString(", ");
+}
+}
+
+class MainComponent::GroupRow : public juce::Component,
+                                private juce::Button::Listener
+{
+public:
+    GroupRow(MainComponent& ownerRef)
+        : owner(ownerRef)
+    {
+        addAndMakeVisible(toggle);
+        toggle.addListener(this);
+        addAndMakeVisible(infoButton);
+        infoButton.setButtonText("Info");
+        infoButton.addListener(this);
+        addAndMakeVisible(nameLabel);
+        nameLabel.setJustificationType(juce::Justification::left);
+        addAndMakeVisible(metaLabel);
+        metaLabel.setJustificationType(juce::Justification::left);
+        metaLabel.setColour(juce::Label::textColourId, juce::Colours::dimgrey);
+    }
+
+    void setRow(int newIndex)
+    {
+        rowIndex = newIndex;
+    }
+
+    void update(const GroupEntry& entry)
+    {
+        juce::ScopedValueSetter<bool> svs(guard, true);
+        toggle.setToggleState(entry.selected, juce::dontSendNotification);
+        nameLabel.setText(entry.group.name, juce::dontSendNotification);
+        metaLabel.setText("[" + entry.mode.toLowerCase() + "]  [" + formatExtCounts(entry.group) + "]", juce::dontSendNotification);
+    }
+
+    void resized() override
+    {
+        auto bounds = getLocalBounds().reduced(4);
+        toggle.setBounds(bounds.removeFromLeft(40));
+        infoButton.setBounds(bounds.removeFromLeft(60));
+        auto nameArea = bounds.removeFromLeft(bounds.getWidth() / 2);
+        nameLabel.setBounds(nameArea);
+        metaLabel.setBounds(bounds);
+    }
+
+private:
+    void buttonClicked(juce::Button* b) override
+    {
+        if (guard)
+            return;
+        if (b == &toggle)
+            owner.onGroupToggled(rowIndex, toggle.getToggleState());
+        else if (b == &infoButton)
+            owner.onGroupInfo(rowIndex);
+    }
+
+    MainComponent& owner;
+    int rowIndex = 0;
+    juce::ToggleButton toggle;
+    juce::TextButton infoButton;
+    juce::Label nameLabel;
+    juce::Label metaLabel;
+    bool guard = false;
+};
+
+class MainComponent::FileRow : public juce::Component,
+                               private juce::Button::Listener
+{
+public:
+    FileRow(MainComponent& ownerRef)
+        : owner(ownerRef)
+    {
+        addAndMakeVisible(toggle);
+        toggle.addListener(this);
+        addAndMakeVisible(nameLabel);
+        nameLabel.setJustificationType(juce::Justification::left);
+        addAndMakeVisible(timeLabel);
+        timeLabel.setColour(juce::Label::textColourId, juce::Colours::dimgrey);
+        addAndMakeVisible(urlLabel);
+        urlLabel.setColour(juce::Label::textColourId, juce::Colours::dimgrey);
+        urlLabel.setJustificationType(juce::Justification::left);
+    }
+
+    void setRow(int idx) { rowIndex = idx; }
+
+    void update(const FileEntry& entry)
+    {
+        juce::ScopedValueSetter<bool> svs(guard, true);
+        toggle.setToggleState(entry.selected, juce::dontSendNotification);
+        nameLabel.setText(entry.file.name, juce::dontSendNotification);
+        juce::String times;
+        times << entry.file.start.toISO8601(true) << " → " << entry.file.end.toISO8601(true);
+        timeLabel.setText(times, juce::dontSendNotification);
+        urlLabel.setText(entry.file.url, juce::dontSendNotification);
+    }
+
+    void resized() override
+    {
+        auto bounds = getLocalBounds().reduced(4);
+        toggle.setBounds(bounds.removeFromLeft(40));
+        nameLabel.setBounds(bounds.removeFromLeft(220));
+        timeLabel.setBounds(bounds.removeFromLeft(260));
+        urlLabel.setBounds(bounds);
+    }
+
+private:
+    void buttonClicked(juce::Button* b) override
+    {
+        if (guard)
+            return;
+        if (b == &toggle)
+            owner.onFileToggled(rowIndex, toggle.getToggleState());
+    }
+
+    MainComponent& owner;
+    int rowIndex = 0;
+    juce::ToggleButton toggle;
+    juce::Label nameLabel;
+    juce::Label timeLabel;
+    juce::Label urlLabel;
+    bool guard = false;
+};
+
+class MainComponent::GroupListModel : public juce::ListBoxModel
+{
+public:
+    explicit GroupListModel(MainComponent& mc) : owner(mc) {}
+
+    int getNumRows() override
+    {
+        return static_cast<int>(owner.groups.size());
+    }
+
+    juce::Component* refreshComponentForRow(int rowNumber, bool, juce::Component* existingComponent) override
+    {
+        auto* row = dynamic_cast<GroupRow*>(existingComponent);
+        if (row == nullptr)
+            row = new GroupRow(owner);
+        row->setRow(rowNumber);
+        row->update(owner.groups.at((size_t) rowNumber));
+        return row;
+    }
+
+private:
+    MainComponent& owner;
+};
+
+class MainComponent::FileListModel : public juce::ListBoxModel
+{
+public:
+    explicit FileListModel(MainComponent& mc) : owner(mc) {}
+
+    int getNumRows() override
+    {
+        return static_cast<int>(owner.files.size());
+    }
+
+    juce::Component* refreshComponentForRow(int rowNumber, bool, juce::Component* existingComponent) override
+    {
+        auto* row = dynamic_cast<FileRow*>(existingComponent);
+        if (row == nullptr)
+            row = new FileRow(owner);
+        row->setRow(rowNumber);
+        row->update(owner.files.at((size_t) rowNumber));
+        return row;
+    }
+
+private:
+    MainComponent& owner;
+};
+
+MainComponent::MainComponent()
+{
+    addAndMakeVisible(siteCombo);
+    addAndMakeVisible(tagEditor);
+    addAndMakeVisible(refreshButton);
+    addAndMakeVisible(listButton);
+    addAndMakeVisible(onlyLongRunsToggle);
+    addAndMakeVisible(previewButton);
+    addAndMakeVisible(downloadButton);
+    addAndMakeVisible(clipButton);
+    addAndMakeVisible(chooseDestButton);
+    addAndMakeVisible(logButton);
+    addAndMakeVisible(destinationLabel);
+    addAndMakeVisible(statusLabel);
+    addAndMakeVisible(metadataView);
+    addAndMakeVisible(setsList);
+    addAndMakeVisible(filesList);
+    addAndMakeVisible(previewSummary);
+    addAndMakeVisible(runsEditor);
+    addAndMakeVisible(selectionLabel);
+
+    tagEditor.setText("dolphin");
+    tagEditor.setTextToShowWhenEmpty("dolphin", juce::Colours::grey);
+    onlyLongRunsToggle.setButtonText("Only runs ≥ 2h");
+    refreshButton.setButtonText("Refresh");
+    listButton.setButtonText("List sets");
+    previewButton.setButtonText("Preview");
+    downloadButton.setButtonText("Download");
+    clipButton.setButtonText("Clip");
+    chooseDestButton.setButtonText("Choose…");
+    logButton.setButtonText("Log…");
+
+    previewButton.setEnabled(false);
+    downloadButton.setEnabled(false);
+    clipButton.setEnabled(false);
+
+    runsEditor.setMultiLine(true);
+    runsEditor.setReadOnly(true);
+    runsEditor.setColour(juce::TextEditor::backgroundColourId, juce::Colours::lightgrey);
+
+    selectionLabel.setText("0 files selected", juce::dontSendNotification);
+
+    refreshButton.addListener(this);
+    listButton.addListener(this);
+    previewButton.addListener(this);
+    downloadButton.addListener(this);
+    clipButton.addListener(this);
+    chooseDestButton.addListener(this);
+    logButton.addListener(this);
+    onlyLongRunsToggle.addListener(this);
+
+    populateSiteCombo();
+
+    destinationLabel.setText(client.getDestinationDirectory().getFullPathName(), juce::dontSendNotification);
+    setStatus("Ready");
+
+    groupListModel = std::make_unique<GroupListModel>(*this);
+    fileListModel = std::make_unique<FileListModel>(*this);
+    setsList.setModel(groupListModel.get());
+    filesList.setModel(fileListModel.get());
+
+    setSize(1280, 880);
+}
+
+MainComponent::~MainComponent()
+{
+    if (logWindow != nullptr)
+        logWindow->setVisible(false);
+}
+
+void MainComponent::resized()
+{
+    auto bounds = getLocalBounds().reduced(12);
+
+    auto row1 = bounds.removeFromTop(32);
+    siteCombo.setBounds(row1.removeFromLeft(220));
+    refreshButton.setBounds(row1.removeFromLeft(80));
+    tagEditor.setBounds(row1.removeFromLeft(160));
+    listButton.setBounds(row1.removeFromLeft(120));
+    onlyLongRunsToggle.setBounds(row1);
+
+    auto row2 = bounds.removeFromTop(32);
+    destinationLabel.setBounds(row2.removeFromLeft(360));
+    chooseDestButton.setBounds(row2.removeFromLeft(120));
+    logButton.setBounds(row2.removeFromLeft(80));
+
+    auto body = bounds.removeFromTop(bounds.getHeight() - 48);
+    auto left = body.removeFromLeft(body.getWidth() / 2);
+    metadataView.setBounds(left.removeFromBottom(220));
+    setsList.setBounds(left);
+
+    auto right = body;
+    previewSummary.setBounds(right.removeFromTop(24));
+    runsEditor.setBounds(right.removeFromTop(120));
+    filesList.setBounds(right.removeFromTop(right.getHeight() - 28));
+    selectionLabel.setBounds(right);
+
+    auto bottom = bounds;
+    previewButton.setBounds(bottom.removeFromLeft(120));
+    downloadButton.setBounds(bottom.removeFromLeft(120));
+    clipButton.setBounds(bottom.removeFromLeft(120));
+    statusLabel.setBounds(bottom);
+}
+
+void MainComponent::buttonClicked(juce::Button* button)
+{
+    if (button == &listButton)
+        handleListSets();
+    else if (button == &previewButton)
+        handlePreview();
+    else if (button == &downloadButton)
+        handleDownload();
+    else if (button == &clipButton)
+        handleClip();
+    else if (button == &chooseDestButton)
+    {
+        juce::FileChooser chooser("Choose destination", client.getDestinationDirectory());
+        if (chooser.browseForDirectory())
+        {
+            client.setDestinationDirectory(chooser.getResult());
+            destinationLabel.setText(chooser.getResult().getFullPathName(), juce::dontSendNotification);
+        }
+    }
+    else if (button == &logButton)
+        toggleLogWindow();
+}
+
+void MainComponent::comboBoxChanged(juce::ComboBox*)
+{
+}
+
+void MainComponent::handleListSets()
+{
+    auto site = client.codeForLabel(siteCombo.getText());
+    auto tag = tagEditor.getText().trim();
+    setStatus("Listing sets…");
+    listButton.setEnabled(false);
+    previewButton.setEnabled(false);
+    downloadButton.setEnabled(false);
+    clipButton.setEnabled(false);
+
+    runInBackground([this, site, tag]() {
+        try
+        {
+            auto groupsResult = client.listProductGroups(site, tag, [this](const juce::String& msg) { logMessage(msg + "\n"); });
+            juce::MessageManager::callAsync([this, groupsResult]() mutable {
+                groups.clear();
+                for (auto& g : groupsResult)
+                {
+                    GroupEntry entry;
+                    entry.group = g;
+                    entry.mode = determineMode(g.name);
+                    entry.selected = false;
+                    groups.push_back(entry);
+                }
+                setsList.updateContent();
+                setsList.repaint();
+                metadataView.showMessage("Select a set and click Info.");
+                previewButton.setEnabled(! groups.empty());
+                listButton.setEnabled(true);
+                setStatus("Found " + juce::String(groups.size()) + " sets. Select and preview.");
+            });
+        }
+        catch (const std::exception& e)
+        {
+            juce::MessageManager::callAsync([this, msg = juce::String(e.what())]() {
+                juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "List failed", msg);
+                listButton.setEnabled(true);
+                setStatus("List failed");
+            });
+        }
+    });
+}
+
+void MainComponent::handlePreview()
+{
+    auto selected = selectedGroupNames();
+    if (selected.isEmpty())
+    {
+        juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::InfoIcon, "Select at least one group", "");
+        return;
+    }
+
+    auto site = client.codeForLabel(siteCombo.getText());
+    auto onlyLong = onlyLongRunsToggle.getToggleState();
+
+    std::vector<ProductGroup> groupsToPreview;
+    groupsToPreview.reserve((size_t) selected.size());
+    for (auto& entry : groups)
+        if (entry.selected)
+            groupsToPreview.push_back(entry.group);
+    if (groupsToPreview.empty())
+        return;
+
+    setStatus("Previewing…");
+    previewButton.setEnabled(false);
+    downloadButton.setEnabled(false);
+    clipButton.setEnabled(false);
+
+    runInBackground([this, site, onlyLong, groupsToPreview = std::move(groupsToPreview)]() mutable {
+        for (size_t idx = 0; idx < groupsToPreview.size(); ++idx)
+        {
+            const auto& group = groupsToPreview[idx];
+            auto name = group.name;
+            try
+            {
+                logMessage("\n=== Preview " + name + " ===\n");
+                auto preview = client.previewGroup(site, group, onlyLong, [this](const juce::String& msg) { logMessage(msg + "\n"); });
+                auto isLast = (idx + 1 == groupsToPreview.size());
+                juce::MessageManager::callAsync([this, name, preview, isLast]() mutable {
+                    previewCache[name] = PreviewCache { preview.mode, preview.windows };
+                    updateFileList(name, preview);
+                    if (isLast)
+                        previewButton.setEnabled(true);
+                    downloadButton.setEnabled(! files.empty());
+                    if (isLast)
+                        setStatus("Preview ready");
+                });
+            }
+            catch (const std::exception& e)
+            {
+                juce::MessageManager::callAsync([this, msg = juce::String(e.what())]() {
+                    juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "Preview failed", msg);
+                    previewButton.setEnabled(true);
+                    setStatus("Preview failed");
+                });
+            }
+        }
+    });
+}
+
+void MainComponent::handleDownload()
+{
+    juce::StringArray urls;
+    for (auto& f : files)
+        if (f.selected)
+            urls.addIfNotAlreadyThere(f.file.url);
+    if (urls.isEmpty())
+    {
+        juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::InfoIcon, "Select at least one file", "");
+        return;
+    }
+
+    setStatus("Downloading files…");
+    downloadButton.setEnabled(false);
+
+    runInBackground([this, urls]() {
+        try
+        {
+            client.downloadFiles(urls, [this](const juce::String& msg) { logMessage(msg + "\n"); });
+            juce::MessageManager::callAsync([this]() {
+                downloadButton.setEnabled(true);
+                clipButton.setEnabled(true);
+                setStatus("Download complete");
+            });
+        }
+        catch (const std::exception& e)
+        {
+            juce::MessageManager::callAsync([this, msg = juce::String(e.what())]() {
+                juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "Download failed", msg);
+                downloadButton.setEnabled(true);
+                setStatus("Download failed");
+            });
+        }
+    });
+}
+
+void MainComponent::handleClip()
+{
+    auto selected = selectedGroupNames();
+    if (selected.isEmpty())
+    {
+        juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::InfoIcon, "Select a group to clip", "");
+        return;
+    }
+
+    juce::StringArray basenames;
+    for (auto& f : files)
+        if (f.selected)
+            basenames.addIfNotAlreadyThere(f.file.name);
+    if (basenames.isEmpty())
+    {
+        juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::InfoIcon, "Select files before clipping", "");
+        return;
+    }
+
+    setStatus("Clipping…");
+    clipButton.setEnabled(false);
+
+    runInBackground([this, selected, basenames]() {
+        try
+        {
+            auto summary = client.clipGroups(selected, previewCache, basenames, [this](const juce::String& msg) { logMessage(msg + "\n"); });
+            juce::MessageManager::callAsync([this, summary]() {
+                clipButton.setEnabled(true);
+                juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::InfoIcon,
+                                                       "Clip complete",
+                                                       "Clips written to: " + summary.directory.getFullPathName());
+                setStatus("Clip complete");
+            });
+        }
+        catch (const std::exception& e)
+        {
+            juce::MessageManager::callAsync([this, msg = juce::String(e.what())]() {
+                juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "Clip failed", msg);
+                clipButton.setEnabled(true);
+                setStatus("Clip failed");
+            });
+        }
+    });
+}
+
+void MainComponent::toggleLogWindow()
+{
+    if (logWindow != nullptr)
+    {
+        logWindow->setVisible(false);
+        logWindow.reset();
+        logEditor.reset();
+        return;
+    }
+
+    auto editor = std::make_unique<juce::TextEditor>();
+    editor->setMultiLine(true);
+    editor->setReadOnly(true);
+    editor->setScrollbarsShown(true);
+    editor->setText("Log window\n", false);
+
+    auto window = std::make_unique<juce::DocumentWindow>("Log", juce::Colours::lightgrey, juce::DocumentWindow::closeButton);
+    window->setUsingNativeTitleBar(true);
+    window->setResizable(true, true);
+    window->setContentOwned(editor.get(), true);
+    window->centreWithSize(480, 360);
+    window->setVisible(true);
+
+    logEditor = std::move(editor);
+    logWindow = std::move(window);
+}
+
+void MainComponent::populateSiteCombo()
+{
+    auto labels = client.siteLabels();
+    siteCombo.clear();
+    for (int i = 0; i < labels.size(); ++i)
+        siteCombo.addItem(labels[i], i + 1);
+    if (labels.size() > 0)
+        siteCombo.setSelectedId(1);
+}
+
+juce::StringArray MainComponent::selectedGroupNames() const
+{
+    juce::StringArray names;
+    for (auto& entry : groups)
+        if (entry.selected)
+            names.add(entry.group.name);
+    return names;
+}
+
+void MainComponent::setStatus(const juce::String& status)
+{
+    statusLabel.setText(status, juce::dontSendNotification);
+}
+
+void MainComponent::logMessage(const juce::String& message)
+{
+    std::cout << message << std::flush;
+    if (logEditor != nullptr)
+    {
+        logEditor->moveCaretToEnd();
+        logEditor->insertTextAtCaret(message);
+    }
+}
+
+void MainComponent::runInBackground(std::function<void()> task)
+{
+    std::thread(std::move(task)).detach();
+}
+
+void MainComponent::onGroupInfo(int index)
+{
+    if (index < 0 || index >= (int) groups.size())
+        return;
+    auto site = client.codeForLabel(siteCombo.getText());
+    auto groupName = groups[(size_t) index].group.name;
+    metadataView.setGroupTitle(groupName);
+    metadataView.showMessage("Loading metadata…");
+
+    runInBackground([this, site, groupName]() {
+        try
+        {
+            juce::String raw;
+            auto summary = client.fetchMetadataSummary(site, groupName, raw, [this](const juce::String& msg) { logMessage(msg + "\n"); });
+            juce::MessageManager::callAsync([this, summary, raw]() {
+                metadataView.setSummary(summary);
+                metadataView.setRawJson(raw);
+            });
+        }
+        catch (const std::exception& e)
+        {
+            juce::MessageManager::callAsync([this, msg = juce::String(e.what())]() {
+                juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon, "Metadata error", msg);
+                metadataView.showMessage("Metadata failed");
+            });
+        }
+    });
+}
+
+void MainComponent::onGroupToggled(int index, bool state)
+{
+    if (index < 0 || index >= (int) groups.size())
+        return;
+    groups[(size_t) index].selected = state;
+}
+
+void MainComponent::onFileToggled(int index, bool state)
+{
+    if (index < 0 || index >= (int) files.size())
+        return;
+    files[(size_t) index].selected = state;
+    updateSelectionLabel();
+}
+
+void MainComponent::selectAllFiles(bool state)
+{
+    for (auto& f : files)
+        f.selected = state;
+    filesList.updateContent();
+    updateSelectionLabel();
+}
+
+void MainComponent::updateFileList(const juce::String& groupName, const PreviewResult& preview)
+{
+    lastPreviewGroup = groupName;
+    previewSummary.setText(preview.summary, juce::dontSendNotification);
+    runsEditor.setText(preview.runsText);
+
+    files.clear();
+    for (auto& file : preview.files)
+    {
+        FileEntry entry;
+        entry.file = file;
+        entry.selected = true;
+        files.push_back(entry);
+    }
+    filesList.updateContent();
+    updateSelectionLabel();
+}
+
+void MainComponent::updateSelectionLabel()
+{
+    int count = 0;
+    for (auto& f : files)
+        if (f.selected)
+            ++count;
+    selectionLabel.setText(juce::String(count) + " files selected", juce::dontSendNotification);
+}
+
+} // namespace sanctsound

--- a/juce_port/Source/MainComponent.h
+++ b/juce_port/Source/MainComponent.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <juce_gui_extra/juce_gui_extra.h>
+#include <map>
+#include <vector>
+
+#include "SanctSoundClient.h"
+#include "MetadataView.h"
+
+namespace sanctsound
+{
+class MainComponent : public juce::Component,
+                      private juce::Button::Listener,
+                      private juce::ComboBox::Listener
+{
+public:
+    MainComponent();
+    ~MainComponent() override;
+
+    void resized() override;
+
+private:
+    struct GroupEntry
+    {
+        ProductGroup group;
+        juce::String mode;
+        bool selected = false;
+    };
+
+    struct FileEntry
+    {
+        ListedFile file;
+        bool selected = true;
+    };
+
+    class GroupRow;
+    class FileRow;
+    class GroupListModel;
+    class FileListModel;
+
+    void buttonClicked(juce::Button* button) override;
+    void comboBoxChanged(juce::ComboBox* comboBoxThatHasChanged) override;
+
+    void handleListSets();
+    void handlePreview();
+    void handleDownload();
+    void handleClip();
+    void toggleLogWindow();
+
+    void populateSiteCombo();
+    juce::StringArray selectedGroupNames() const;
+    void setStatus(const juce::String& status);
+    void logMessage(const juce::String& message);
+
+    void runInBackground(std::function<void()> task);
+
+    void onGroupInfo(int index);
+    void onGroupToggled(int index, bool state);
+    void onFileToggled(int index, bool state);
+    void selectAllFiles(bool state);
+
+    void updateFileList(const juce::String& groupName, const PreviewResult& preview);
+    void updateSelectionLabel();
+
+    SanctSoundClient client;
+
+    juce::ComboBox siteCombo;
+    juce::TextEditor tagEditor;
+    juce::TextButton refreshButton;
+    juce::TextButton listButton;
+    juce::ToggleButton onlyLongRunsToggle;
+    juce::TextButton previewButton;
+    juce::TextButton downloadButton;
+    juce::TextButton clipButton;
+    juce::TextButton chooseDestButton;
+    juce::TextButton logButton;
+    juce::Label destinationLabel;
+    juce::Label statusLabel;
+
+    MetadataView metadataView;
+
+    juce::ListBox setsList { "Sets" };
+    juce::ListBox filesList { "Files" };
+    juce::Label previewSummary;
+    juce::TextEditor runsEditor;
+    juce::Label selectionLabel;
+
+    std::unique_ptr<juce::DocumentWindow> logWindow;
+    std::unique_ptr<juce::TextEditor> logEditor;
+
+    std::vector<GroupEntry> groups;
+    std::vector<FileEntry> files;
+    std::map<juce::String, PreviewCache> previewCache;
+    juce::String lastPreviewGroup;
+
+    std::unique_ptr<GroupListModel> groupListModel;
+    std::unique_ptr<FileListModel> fileListModel;
+
+    juce::CriticalSection stateLock;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainComponent)
+};
+
+} // namespace sanctsound

--- a/juce_port/Source/MetadataView.cpp
+++ b/juce_port/Source/MetadataView.cpp
@@ -1,0 +1,230 @@
+#include "MetadataView.h"
+
+namespace sanctsound
+{
+class MetadataView::SummaryPanel : public juce::Component
+{
+public:
+    SummaryPanel(juce::Label& messageLabelRef,
+                 juce::Label& site,
+                 juce::Label& deployment,
+                 juce::Label& platform,
+                 juce::Label& recorder,
+                 juce::Label& coordinates,
+                 juce::Label& start,
+                 juce::Label& end,
+                 juce::Label& sampleRate,
+                 juce::Label& note,
+                 std::vector<std::unique_ptr<juce::Label>>& titlesRef)
+        : message(messageLabelRef),
+          siteValue(site),
+          deploymentValue(deployment),
+          platformValue(platform),
+          recorderValue(recorder),
+          coordinatesValue(coordinates),
+          startValue(start),
+          endValue(end),
+          sampleRateValue(sampleRate),
+          noteValue(note),
+          titles(titlesRef)
+    {
+    }
+
+    void resized() override
+    {
+        auto area = getLocalBounds().reduced(12);
+        if (message.isVisible())
+        {
+            message.setBounds(area);
+            return;
+        }
+
+        auto layoutCard = [](juce::Rectangle<int> bounds, juce::Label* title, juce::Label& value)
+        {
+            if (title != nullptr)
+            {
+                auto titleBounds = bounds.removeFromTop(18);
+                title->setBounds(titleBounds);
+            }
+            value.setBounds(bounds.reduced(0, 2));
+        };
+
+        auto columnWidth = juce::jmax(120, area.getWidth() / 3);
+        auto rowHeight = 72;
+
+        auto row1 = area.removeFromTop(rowHeight);
+        layoutCard(row1.removeFromLeft(columnWidth), titles.size() > 0 ? titles[0].get() : nullptr, siteValue);
+        layoutCard(row1.removeFromLeft(columnWidth), titles.size() > 1 ? titles[1].get() : nullptr, deploymentValue);
+        layoutCard(row1, titles.size() > 2 ? titles[2].get() : nullptr, platformValue);
+
+        auto row2 = area.removeFromTop(rowHeight);
+        layoutCard(row2.removeFromLeft(columnWidth), titles.size() > 3 ? titles[3].get() : nullptr, recorderValue);
+        layoutCard(row2, titles.size() > 4 ? titles[4].get() : nullptr, coordinatesValue);
+
+        auto row3 = area.removeFromTop(rowHeight);
+        layoutCard(row3.removeFromLeft(columnWidth), titles.size() > 5 ? titles[5].get() : nullptr, startValue);
+        layoutCard(row3.removeFromLeft(columnWidth), titles.size() > 6 ? titles[6].get() : nullptr, endValue);
+        layoutCard(row3, titles.size() > 7 ? titles[7].get() : nullptr, sampleRateValue);
+
+        layoutCard(area, titles.size() > 8 ? titles[8].get() : nullptr, noteValue);
+    }
+
+private:
+    juce::Label& message;
+    juce::Label& siteValue;
+    juce::Label& deploymentValue;
+    juce::Label& platformValue;
+    juce::Label& recorderValue;
+    juce::Label& coordinatesValue;
+    juce::Label& startValue;
+    juce::Label& endValue;
+    juce::Label& sampleRateValue;
+    juce::Label& noteValue;
+    std::vector<std::unique_ptr<juce::Label>>& titles;
+};
+
+MetadataView::MetadataView()
+{
+    addAndMakeVisible(titleLabel);
+    titleLabel.setText("Metadata", juce::dontSendNotification);
+    titleLabel.setJustificationType(juce::Justification::left);
+    titleLabel.setFont(juce::Font(16.0f, juce::Font::bold));
+
+    summaryTab = std::make_unique<SummaryPanel>(messageLabel,
+                                                siteValue,
+                                                deploymentValue,
+                                                platformValue,
+                                                recorderValue,
+                                                coordinatesValue,
+                                                startValue,
+                                                endValue,
+                                                sampleRateValue,
+                                                noteValue,
+                                                titleLabels);
+
+    tabs.addTab("Summary", juce::Colours::transparentBlack, summaryTab.get(), false);
+
+    rawEditor.setMultiLine(true, true);
+    rawEditor.setReadOnly(true);
+    rawEditor.setScrollbarsShown(true, true);
+    rawEditor.setFont(juce::Font(13.0f));
+    rawEditor.setTextToShowWhenEmpty("Select a set to view metadata.", juce::Colours::grey);
+    tabs.addTab("Raw JSON", juce::Colours::transparentBlack, &rawEditor, false);
+
+    addAndMakeVisible(tabs);
+
+    initialiseSummaryCards();
+    showMessage("Select a set to view metadata.");
+}
+
+void MetadataView::initialiseSummaryCards()
+{
+    summaryTab->addAndMakeVisible(messageLabel);
+    messageLabel.setJustificationType(juce::Justification::centred);
+    messageLabel.setColour(juce::Label::textColourId, juce::Colours::darkgrey);
+
+    auto configureValue = [](juce::Label& label)
+    {
+        label.setJustificationType(juce::Justification::left);
+        label.setFont(juce::Font(14.0f));
+        label.setColour(juce::Label::textColourId, juce::Colours::black);
+        label.setBorderSize(juce::BorderSize<int>(2));
+        label.setMinimumHorizontalScale(0.6f);
+    };
+
+    auto addCard = [this, configureValue](const juce::String& title, juce::Label& value)
+    {
+        auto label = std::make_unique<juce::Label>();
+        label->setText(title, juce::dontSendNotification);
+        label->setJustificationType(juce::Justification::left);
+        label->setColour(juce::Label::textColourId, juce::Colours::darkgrey);
+        label->setFont(juce::Font(12.5f, juce::Font::bold));
+        summaryTab->addAndMakeVisible(label.get());
+        titleLabels.push_back(std::move(label));
+
+        configureValue(value);
+        summaryTab->addAndMakeVisible(value);
+    };
+
+    addCard("SITE", siteValue);
+    addCard("DEPLOYMENT", deploymentValue);
+    addCard("PLATFORM", platformValue);
+    addCard("RECORDER", recorderValue);
+    addCard("COORDINATES / DEPTH", coordinatesValue);
+    addCard("START (UTC)", startValue);
+    addCard("END (UTC)", endValue);
+    addCard("SAMPLE RATE", sampleRateValue);
+    addCard("LOCATION NOTE", noteValue);
+}
+
+void MetadataView::setGroupTitle(const juce::String& groupName)
+{
+    titleLabel.setText(groupName.isNotEmpty() ? groupName : juce::String("Metadata"), juce::dontSendNotification);
+}
+
+void MetadataView::setSummary(const MetadataSummary& summary)
+{
+    messageLabel.setVisible(false);
+    for (auto& title : titleLabels)
+        title->setVisible(true);
+
+    auto setValue = [](juce::Label& label, const juce::String& text)
+    {
+        auto trimmed = text.trim();
+        label.setText(trimmed.isNotEmpty() ? trimmed : juce::String("—"), juce::dontSendNotification);
+        label.setVisible(true);
+    };
+
+    setValue(siteValue, summary.site);
+    setValue(deploymentValue, summary.deployment);
+    setValue(platformValue, summary.platform);
+    setValue(recorderValue, summary.recorder);
+    setValue(coordinatesValue, summary.coordinates);
+    setValue(startValue, summary.start);
+    setValue(endValue, summary.end);
+    setValue(sampleRateValue, summary.sampleRate);
+    setValue(noteValue, summary.note);
+
+    summaryTab->resized();
+}
+
+void MetadataView::setRawJson(const juce::String& rawText)
+{
+    rawEditor.setText(rawText, juce::dontSendNotification);
+}
+
+void MetadataView::showMessage(const juce::String& message)
+{
+    messageLabel.setText(message, juce::dontSendNotification);
+    messageLabel.setVisible(true);
+    for (auto& title : titleLabels)
+        title->setVisible(false);
+
+    auto hideValue = [](juce::Label& label)
+    {
+        label.setText("—", juce::dontSendNotification);
+        label.setVisible(false);
+    };
+
+    hideValue(siteValue);
+    hideValue(deploymentValue);
+    hideValue(platformValue);
+    hideValue(recorderValue);
+    hideValue(coordinatesValue);
+    hideValue(startValue);
+    hideValue(endValue);
+    hideValue(sampleRateValue);
+    hideValue(noteValue);
+
+    summaryTab->resized();
+}
+
+void MetadataView::resized()
+{
+    auto bounds = getLocalBounds();
+    auto header = bounds.removeFromTop(30);
+    titleLabel.setBounds(header);
+    tabs.setBounds(bounds);
+}
+
+} // namespace sanctsound

--- a/juce_port/Source/MetadataView.h
+++ b/juce_port/Source/MetadataView.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <juce_gui_extra/juce_gui_extra.h>
+#include <vector>
+#include <memory>
+#include "PreviewModels.h"
+
+namespace sanctsound
+{
+class MetadataView : public juce::Component
+{
+public:
+    MetadataView();
+
+    void setGroupTitle(const juce::String& groupName);
+    void setSummary(const MetadataSummary& summary);
+    void setRawJson(const juce::String& rawText);
+    void showMessage(const juce::String& message);
+
+    void resized() override;
+
+private:
+    void initialiseSummaryCards();
+
+    juce::Label titleLabel;
+    juce::TabbedComponent tabs { juce::TabbedButtonBar::TabsAtTop };
+    class SummaryPanel;
+    std::unique_ptr<SummaryPanel> summaryTab;
+    juce::TextEditor rawEditor;
+    juce::Label messageLabel;
+    std::vector<std::unique_ptr<juce::Label>> titleLabels;
+
+    juce::Label siteValue;
+    juce::Label deploymentValue;
+    juce::Label platformValue;
+    juce::Label recorderValue;
+    juce::Label coordinatesValue;
+    juce::Label startValue;
+    juce::Label endValue;
+    juce::Label sampleRateValue;
+    juce::Label noteValue;
+};
+
+} // namespace sanctsound

--- a/juce_port/Source/PreviewModels.cpp
+++ b/juce_port/Source/PreviewModels.cpp
@@ -1,0 +1,6 @@
+#include "PreviewModels.h"
+
+namespace sanctsound
+{
+// Data-only structures; no implementation required here.
+}

--- a/juce_port/Source/PreviewModels.h
+++ b/juce_port/Source/PreviewModels.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+#include <map>
+
+namespace sanctsound
+{
+struct ProductGroup
+{
+    juce::String name;
+    juce::String mode;
+    juce::StringArray paths;
+    std::map<juce::String, int, std::less<>> extCounts;
+};
+
+struct MetadataSummary
+{
+    juce::String site;
+    juce::String deployment;
+    juce::String platform;
+    juce::String recorder;
+    juce::String coordinates;
+    juce::String start;
+    juce::String end;
+    juce::String sampleRate;
+    juce::String note;
+    juce::String rawText;
+};
+
+struct ListedFile
+{
+    juce::String url;
+    juce::String name;
+    juce::Time start;
+    juce::Time end;
+    juce::String folder;
+};
+
+struct PreviewWindow
+{
+    juce::Time start;
+    juce::Time end;
+};
+
+struct PreviewResult
+{
+    juce::String mode;
+    juce::String summary;
+    juce::String runsText;
+    juce::Array<ListedFile> files;
+    juce::Array<PreviewWindow> windows;
+    juce::StringArray urls;
+    juce::StringArray names;
+};
+
+struct ClipRow
+{
+    juce::String clipName;
+    juce::String sourceNames;
+    juce::String startIso;
+    juce::String endIso;
+    double durationSeconds = 0.0;
+    juce::String mode;
+};
+
+struct ClipSummary
+{
+    int totalWindows = 0;
+    int written = 0;
+    int skipped = 0;
+    juce::String mode;
+    juce::File directory;
+    juce::Array<ClipRow> manifestRows;
+};
+
+} // namespace sanctsound

--- a/juce_port/Source/SanctSoundClient.cpp
+++ b/juce_port/Source/SanctSoundClient.cpp
@@ -1,0 +1,1213 @@
+#include "SanctSoundClient.h"
+
+#include "Utilities.h"
+
+#include <juce_core/juce_core.h>
+#include <juce_data_structures/juce_data_structures.h>
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <stdexcept>
+#include <vector>
+
+namespace sanctsound
+{
+namespace
+{
+const juce::StringArray kKnownCodes {
+    "ci01","ci02","ci03","ci04","ci05",
+    "fk01","fk02","fk03","fk04",
+    "gr01","gr02","gr03",
+    "hi01","hi03","hi04","hi05","hi06",
+    "mb01","mb02","mb03",
+    "oc01","oc02","oc03","oc04",
+    "pm01","pm02","pm05",
+    "sb01","sb02","sb03"
+};
+
+const std::map<juce::String, juce::String, std::less<>> kSitePrefixName {
+    { "ci", "Channel Islands" },
+    { "fk", "Florida Keys" },
+    { "gr", "Gray's Reef" },
+    { "hi", "Hawaiian Islands" },
+    { "mb", "Monterey Bay" },
+    { "oc", "Olympic Coast" },
+    { "pm", "Papah\u0101naumoku\u0101kea" },
+    { "sb", "Stellwagen Bank" }
+};
+
+juce::String siteLabelForCode(const juce::String& code)
+{
+    auto c = code.trim().toLowerCase();
+    auto prefix = c.substring(0, 2);
+    auto friendly = kSitePrefixName.count(prefix) ? kSitePrefixName.at(prefix) : prefix.toUpperCase();
+    return friendly + " — " + c.toUpperCase();
+}
+
+juce::String labelToCode(const juce::String& label)
+{
+    if (label.contains("—"))
+        return label.fromLastOccurrenceOf("—", false, false).trim().toLowerCase();
+    if (label.contains("-"))
+        return label.fromLastOccurrenceOf("-", false, false).trim().toLowerCase();
+    return label.trim().toLowerCase();
+}
+
+juce::StringArray chooseBestFiles(const juce::StringArray& paths)
+{
+    juce::StringArray preferred { ".csv", ".nc", ".json" };
+    for (auto& ext : preferred)
+    {
+        juce::StringArray matches;
+        for (auto& p : paths)
+            if (p.endsWithIgnoreCase(ext))
+                matches.add(p);
+        if (! matches.isEmpty())
+            return matches;
+    }
+    return paths;
+}
+
+struct AudioReference
+{
+    juce::String url;
+    juce::String name;
+    juce::Time start;
+    juce::Time end;
+    juce::String folder;
+};
+
+struct LocalAudio
+{
+    juce::File file;
+    juce::String name;
+    juce::Time start;
+    juce::Time end;
+    juce::String folder;
+};
+
+bool timeLessThan(const juce::Time& a, const juce::Time& b)
+{
+    return a.toMilliseconds() < b.toMilliseconds();
+}
+
+bool timeLessThanOrEqual(const juce::Time& a, const juce::Time& b)
+{
+    return a.toMilliseconds() <= b.toMilliseconds();
+}
+
+juce::Optional<juce::Time> parseAudioStartFromName(const juce::String& name)
+{
+    auto trimmed = name.trim();
+    auto underscore = trimmed.lastIndexOfChar('_');
+    auto dot = trimmed.lastIndexOfChar('.');
+    if (underscore < 0 || dot < 0 || dot <= underscore)
+        return {};
+
+    auto token = trimmed.substring(underscore + 1, dot);
+    juce::Time parsed;
+    if (parseTimestamp(token, parsed))
+        return parsed;
+
+    if (token.length() == 12 && token.containsOnly("0123456789"))
+    {
+        int yy = token.substring(0, 2).getIntValue();
+        int year = yy <= 69 ? 2000 + yy : 1900 + yy;
+        int month = token.substring(2, 4).getIntValue();
+        int day = token.substring(4, 6).getIntValue();
+        int hour = token.substring(6, 8).getIntValue();
+        int minute = token.substring(8, 10).getIntValue();
+        int second = token.substring(10, 12).getIntValue();
+        return juce::Time(year, month, day, hour, minute, second, 0, false);
+    }
+
+    return {};
+}
+
+juce::String folderFromSet(const juce::String& setName)
+{
+    auto lower = setName.toLowerCase();
+    auto pos = lower.indexOf("sanctsound_");
+    if (pos < 0)
+        return {};
+    for (int i = pos; i + 18 <= lower.length(); ++i)
+    {
+        auto candidate = lower.substring(i, i + 18);
+        if (candidate.startsWith("sanctsound_") &&
+            juce::CharacterFunctions::isLetter(candidate[11]) &&
+            juce::CharacterFunctions::isLetter(candidate[12]) &&
+            juce::CharacterFunctions::isDigit(candidate[13]) &&
+            juce::CharacterFunctions::isDigit(candidate[14]) &&
+            candidate[15] == '_' &&
+            juce::CharacterFunctions::isDigit(candidate[16]) &&
+            juce::CharacterFunctions::isDigit(candidate[17]))
+            return candidate;
+    }
+    return {};
+}
+
+juce::Array<PreviewWindow> groupConsecutive(const juce::Array<juce::Time>& points, const juce::RelativeTime& step)
+{
+    juce::Array<PreviewWindow> runs;
+    if (points.isEmpty())
+        return runs;
+
+    auto start = points[0];
+    auto prev = points[0];
+    auto stepMs = step.inMilliseconds();
+
+    for (int i = 1; i < points.size(); ++i)
+    {
+        auto p = points[i];
+        auto diff = p.toMilliseconds() - prev.toMilliseconds();
+        if (std::llabs(diff - (long long) stepMs) <= 1)
+        {
+            prev = p;
+            continue;
+        }
+
+        runs.add({ start, prev + step });
+        start = p;
+        prev = p;
+    }
+    runs.add({ start, prev + step });
+    return runs;
+}
+
+juce::Array<juce::Time> expandRuns(const juce::Array<PreviewWindow>& runs, const juce::RelativeTime& step)
+{
+    juce::Array<juce::Time> out;
+    for (auto& r : runs)
+    {
+        auto t = r.start;
+        while (timeLessThan(t, r.end))
+        {
+            out.add(t);
+            t = t + step;
+        }
+    }
+    return out;
+}
+
+bool isNumeric(const juce::String& text)
+{
+    auto t = text.trim();
+    if (t.isEmpty())
+        return false;
+    for (auto ch : t)
+        if (! (juce::CharacterFunctions::isDigit(ch) || ch == '.' || ch == '-' || ch == '+'))
+            return false;
+    return true;
+}
+
+int detectDatetimeColumn(const CsvTable& table, double minFraction)
+{
+    if (table.rows.isEmpty())
+        return -1;
+    auto rowCount = table.rows.size();
+    int bestCol = -1;
+    int bestMatches = 0;
+    for (int col = 0; col < table.header.size(); ++col)
+    {
+        int matches = 0;
+        for (auto& row : table.rows)
+        {
+            if (col >= row.size())
+                continue;
+            juce::Time parsed;
+            if (parseTimestamp(row[col], parsed))
+                ++matches;
+        }
+        if (matches > bestMatches && matches >= static_cast<int>(std::ceil(rowCount * minFraction)))
+        {
+            bestMatches = matches;
+            bestCol = col;
+        }
+    }
+    return bestCol;
+}
+
+int detectBinaryColumn(const CsvTable& table, int skipCol)
+{
+    int bestCol = -1;
+    int bestCount = 0;
+    for (int col = 0; col < table.header.size(); ++col)
+    {
+        if (col == skipCol)
+            continue;
+        int ones = 0;
+        int total = 0;
+        bool valid = false;
+        for (auto& row : table.rows)
+        {
+            if (col >= row.size())
+                continue;
+            auto field = row[col].trim();
+            if (! isNumeric(field))
+                continue;
+            auto value = field.getDoubleValue();
+            int rounded = static_cast<int>(std::round(value));
+            if (rounded == 0 || rounded == 1)
+            {
+                valid = true;
+                ++total;
+                if (rounded == 1)
+                    ++ones;
+            }
+        }
+        if (valid && ones > 0 && total > 0 && ones > bestCount)
+        {
+            bestCol = col;
+            bestCount = ones;
+        }
+    }
+    return bestCol;
+}
+
+juce::Array<juce::Time> parsePresenceHoursFromCsv(const juce::File& file)
+{
+    auto table = readCsvFile(file);
+    auto hourCol = detectDatetimeColumn(table, 0.1);
+    auto presenceCol = detectBinaryColumn(table, hourCol);
+    if (hourCol < 0 || presenceCol < 0)
+        throw std::runtime_error("Could not detect hour/presence columns in " + file.getFileName().toStdString());
+
+    juce::Array<juce::Time> hours;
+    for (auto& row : table.rows)
+    {
+        if (hourCol >= row.size() || presenceCol >= row.size())
+            continue;
+        auto flag = row[presenceCol].trim();
+        if (! isNumeric(flag))
+            continue;
+        auto val = row[presenceCol].getDoubleValue();
+        if (std::round(val) != 1)
+            continue;
+        juce::Time parsed;
+        if (! parseTimestamp(row[hourCol], parsed))
+            continue;
+        auto truncated = juce::Time(parsed.getYear(), parsed.getMonth(), parsed.getDayOfMonth(), parsed.getHours(), 0, 0, 0, false);
+        hours.addIfNotAlreadyThere(truncated);
+    }
+    std::sort(hours.begin(), hours.end(), [](const juce::Time& a, const juce::Time& b) { return timeLessThan(a, b); });
+    return hours;
+}
+
+juce::Array<juce::Time> parsePresenceDaysFromCsv(const juce::File& file)
+{
+    auto table = readCsvFile(file);
+    auto dtCol = detectDatetimeColumn(table, 0.05);
+    auto presenceCol = detectBinaryColumn(table, dtCol);
+    if (dtCol < 0 || presenceCol < 0)
+        throw std::runtime_error("Could not detect date/presence columns in " + file.getFileName().toStdString());
+
+    juce::Array<juce::Time> days;
+    for (auto& row : table.rows)
+    {
+        if (dtCol >= row.size() || presenceCol >= row.size())
+            continue;
+        auto flag = row[presenceCol].trim();
+        if (! isNumeric(flag))
+            continue;
+        auto val = row[presenceCol].getDoubleValue();
+        if (std::round(val) != 1)
+            continue;
+        juce::Time parsed;
+        if (! parseTimestamp(row[dtCol], parsed))
+            continue;
+        auto truncated = juce::Time(parsed.getYear(), parsed.getMonth(), parsed.getDayOfMonth(), 0, 0, 0, 0, false);
+        days.addIfNotAlreadyThere(truncated);
+    }
+    std::sort(days.begin(), days.end(), [](const juce::Time& a, const juce::Time& b) { return timeLessThan(a, b); });
+    return days;
+}
+
+juce::Array<PreviewWindow> parseEventsFromCsv(const juce::File& file)
+{
+    auto table = readCsvFile(file);
+    auto dtCol = detectDatetimeColumn(table, 0.05);
+    if (dtCol < 0)
+        throw std::runtime_error("No usable datetime column in " + file.getFileName().toStdString());
+
+    int endCol = -1;
+    for (int i = 0; i < table.header.size(); ++i)
+    {
+        if (i == dtCol)
+            continue;
+        auto header = table.header[i].toLowerCase();
+        if (header.contains("end"))
+        {
+            endCol = i;
+            break;
+        }
+    }
+
+    int durationCol = -1;
+    for (int i = 0; i < table.header.size(); ++i)
+    {
+        auto header = table.header[i].toLowerCase();
+        if (header.contains("duration") || header.contains("dur") || header.contains("length"))
+        {
+            durationCol = i;
+            break;
+        }
+    }
+
+    juce::Array<PreviewWindow> events;
+    const double fallbackSeconds = 60.0;
+
+    for (int rowIdx = 0; rowIdx < table.rows.size(); ++rowIdx)
+    {
+        auto& row = table.rows[rowIdx];
+        if (dtCol >= row.size())
+            continue;
+        juce::Time start;
+        if (! parseTimestamp(row[dtCol], start))
+            continue;
+
+        juce::Time end;
+        if (endCol >= 0 && endCol < row.size() && parseTimestamp(row[endCol], end))
+        {
+            if (! timeLessThan(start, end))
+                end = start + juce::RelativeTime::seconds(fallbackSeconds);
+        }
+        else
+        {
+            double duration = fallbackSeconds;
+            if (durationCol >= 0 && durationCol < row.size() && isNumeric(row[durationCol]))
+            {
+                auto v = row[durationCol].getDoubleValue();
+                if (v > 0)
+                    duration = v;
+            }
+            end = start + juce::RelativeTime::seconds(duration);
+        }
+        events.add({ start, end });
+    }
+
+    std::sort(events.begin(), events.end(), [](const PreviewWindow& a, const PreviewWindow& b)
+    {
+        return timeLessThan(a.start, b.start);
+    });
+
+    return events;
+}
+
+juce::var findFirst(const juce::var& obj, const std::vector<juce::String>& keys)
+{
+    if (obj.isObject())
+    {
+        if (auto* dict = obj.getDynamicObject())
+        {
+            for (auto& k : dict->getProperties())
+            {
+                auto keyLower = k.name.toString().toLowerCase();
+                for (auto& target : keys)
+                    if (keyLower == target.toLowerCase())
+                        return k.value;
+            }
+            for (auto& k : dict->getProperties())
+            {
+                auto child = findFirst(k.value, keys);
+                if (! child.isVoid())
+                    return child;
+            }
+        }
+    }
+    else if (obj.isArray())
+    {
+        if (auto* arr = obj.getArray())
+        {
+            for (auto& item : *arr)
+            {
+                auto child = findFirst(item, keys);
+                if (! child.isVoid())
+                    return child;
+            }
+        }
+    }
+    return {};
+}
+
+MetadataSummary buildSummaryFromJson(const juce::var& meta)
+{
+    MetadataSummary summary;
+    auto pick = [&](std::initializer_list<juce::String> names)
+    {
+        std::vector<juce::String> keys(names);
+        auto value = findFirst(meta, keys);
+        if (value.isString())
+            return value.toString();
+        if (value.isInt())
+            return juce::String(static_cast<int>(value));
+        if (value.isDouble())
+            return juce::String(static_cast<double>(value));
+        return juce::String();
+    };
+
+    summary.site = pick({ "site_name", "site" });
+    summary.deployment = pick({ "deployment_name", "deployment" });
+    summary.platform = pick({ "platform_name", "platform" });
+    summary.recorder = pick({ "recorder", "model", "instrument_model" });
+    auto lat = pick({ "latitude", "lat" });
+    auto lon = pick({ "longitude", "lon" });
+    auto depth = pick({ "depth", "water_depth", "sensor_depth" });
+    juce::StringArray coordParts;
+    if (lat.isNotEmpty()) coordParts.add(lat);
+    if (lon.isNotEmpty()) coordParts.add(lon);
+    if (depth.isNotEmpty()) coordParts.add(depth + " m");
+    summary.coordinates = coordParts.joinIntoString(", ");
+    summary.start = pick({ "start_time", "start" });
+    summary.end = pick({ "end_time", "end" });
+    summary.sampleRate = pick({ "sample_rate", "sample_rate_hz", "sampling_rate" });
+    summary.note = pick({ "location_note", "comments" });
+    return summary;
+}
+
+juce::Array<AudioReference> listAudioFilesInFolder(const juce::String& site,
+                                                   const juce::String& folder,
+                                                   const juce::Time& tmin,
+                                                   const juce::Time& tmax,
+                                                   const juce::String& audioPrefix)
+{
+    juce::Array<AudioReference> files;
+    auto pattern = audioPrefix + "/" + site + "/" + folder + "/audio/*.flac";
+    auto result = runCommand({ "gsutil", "ls", "-r", pattern });
+    if (result.exitCode != 0)
+        throw std::runtime_error(humaniseError("gsutil ls", result).toStdString());
+
+    juce::StringArray lines;
+    lines.addLines(result.output);
+
+    juce::Optional<AudioReference> leftCandidate;
+    for (auto& line : lines)
+    {
+        auto url = line.trim();
+        if (! (url.startsWith("gs://") && url.endsWithIgnoreCase(".flac")))
+            continue;
+        auto name = url.fromLastOccurrenceOf("/", false, false);
+        auto startOpt = parseAudioStartFromName(name);
+        if (! startOpt)
+            continue;
+        auto start = *startOpt;
+        if (tmin.toMilliseconds() != 0 && timeLessThan(start, tmin))
+        {
+            if (! leftCandidate.hasValue() || timeLessThan(leftCandidate->start, start))
+                leftCandidate = AudioReference{ url, name, start, {}, folder };
+            continue;
+        }
+        if (tmax.toMilliseconds() != 0 && timeLessThan(tmax, start))
+            continue;
+        files.add({ url, name, start, {}, folder });
+    }
+
+    if (leftCandidate.hasValue())
+    {
+        if (tmin.toMilliseconds() == 0 || (tmin - leftCandidate->start) <= juce::RelativeTime::hours(6))
+            files.add(leftCandidate.get());
+    }
+
+    std::sort(files.begin(), files.end(), [](const AudioReference& a, const AudioReference& b)
+    {
+        if (timeLessThan(a.start, b.start)) return true;
+        if (timeLessThan(b.start, a.start)) return false;
+        return a.folder < b.folder;
+    });
+
+    for (int i = 0; i < files.size(); ++i)
+    {
+        if (i + 1 < files.size() && files[i + 1].folder == files[i].folder)
+        {
+            auto end = files[i + 1].start;
+            if (! timeLessThan(files[i].start, end))
+                end = files[i].start + juce::RelativeTime::seconds(1);
+            files.getReference(i).end = end;
+        }
+        else
+        {
+            files.getReference(i).end = files[i].start + juce::RelativeTime::hours(1);
+        }
+    }
+
+    return files;
+}
+
+juce::Array<AudioReference> listAudioFilesAcross(const juce::String& site,
+                                                const juce::String& preferredFolder,
+                                                const juce::Time& tmin,
+                                                const juce::Time& tmax,
+                                                const juce::String& audioPrefix)
+{
+    auto base = audioPrefix + "/" + site + "/";
+    auto result = runCommand({ "gsutil", "ls", base });
+    if (result.exitCode != 0)
+        throw std::runtime_error(humaniseError("gsutil ls", result).toStdString());
+
+    juce::StringArray folders;
+    juce::StringArray lines;
+    lines.addLines(result.output);
+    for (auto& line : lines)
+    {
+        if (! line.trim().endsWithChar('/'))
+            continue;
+        auto name = line.trim().upToLastOccurrenceOf("/", false, false).fromLastOccurrenceOf("/", false, false);
+        if (name.startsWithIgnoreCase("sanctsound_"))
+            folders.add(name);
+    }
+
+    juce::StringArray ordered;
+    if (preferredFolder.isNotEmpty())
+        ordered.add(preferredFolder);
+    for (auto& f : folders)
+        if (! ordered.contains(f))
+            ordered.add(f);
+
+    juce::Array<AudioReference> all;
+    for (auto& folder : ordered)
+    {
+        auto files = listAudioFilesInFolder(site, folder, tmin, tmax, audioPrefix);
+        all.addArray(files);
+    }
+
+    std::sort(all.begin(), all.end(), [](const AudioReference& a, const AudioReference& b)
+    {
+        if (timeLessThan(a.start, b.start)) return true;
+        if (timeLessThan(b.start, a.start)) return false;
+        return a.folder < b.folder;
+    });
+    return all;
+}
+
+void minimalUnionForWindows(const juce::Array<AudioReference>& files,
+                            const juce::Array<PreviewWindow>& windows,
+                            juce::StringArray& urls,
+                            juce::StringArray& names)
+{
+    if (files.isEmpty() || windows.isEmpty())
+        return;
+
+    auto pickWindow = [&](const PreviewWindow& w)
+    {
+        juce::Array<int> chosen;
+        int index = -1;
+        for (int i = 0; i < files.size(); ++i)
+        {
+            if (timeLessThanOrEqual(files[i].start, w.start))
+                index = i;
+            else
+                break;
+        }
+        if (index < 0)
+            return chosen;
+        chosen.add(index);
+        if (timeLessThan(files[index].end, w.end) && index + 1 < files.size())
+            chosen.add(index + 1);
+        return chosen;
+    };
+
+    for (auto& w : windows)
+    {
+        auto chosen = pickWindow(w);
+        for (auto idx : chosen)
+        {
+            urls.addIfNotAlreadyThere(files[idx].url);
+            names.addIfNotAlreadyThere(files[idx].name);
+        }
+    }
+}
+
+struct DownloadedFile
+{
+    juce::File localFile;
+    juce::String url;
+};
+
+std::vector<DownloadedFile> downloadFilesTo(const juce::StringArray& urls,
+                                            const juce::File& dest,
+                                            SanctSoundClient::LogFn log)
+{
+    std::vector<DownloadedFile> out;
+    for (auto& url : urls)
+    {
+        log("$ gsutil cp " + url + " " + dest.getFullPathName() + "/");
+        auto result = runCommand({ "gsutil", "cp", url, dest.getFullPathName() + "/" });
+        if (result.exitCode != 0)
+            throw std::runtime_error(humaniseError("gsutil cp", result).toStdString());
+        auto base = url.fromLastOccurrenceOf("/", false, false);
+        out.push_back({ dest.getChildFile(base), url });
+    }
+    return out;
+}
+
+juce::var parseJson(const juce::String& text)
+{
+    return juce::JSON::parse(text);
+}
+
+juce::String ffprobeDuration(const juce::File& file, double& outSeconds)
+{
+    auto result = runCommand({ "ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", file.getFullPathName() });
+    if (result.exitCode != 0)
+        return humaniseError("ffprobe", result);
+    outSeconds = result.output.trim().getDoubleValue();
+    return {};
+}
+
+juce::String ffmpegCut(const juce::File& source,
+                       double startSeconds,
+                       double durationSeconds,
+                       const juce::File& outFile,
+                       int sampleRate,
+                       bool mono,
+                       const juce::String& sampleFmt)
+{
+    juce::StringArray args { "ffmpeg", "-y", "-loglevel", "error", "-ss", juce::String(startSeconds, 3), "-t", juce::String(durationSeconds, 3), "-i", source.getFullPathName() };
+    if (mono)
+        args.addArray({ "-ac", "1" });
+    args.addArray({ "-ar", juce::String(sampleRate), "-sample_fmt", sampleFmt, outFile.getFullPathName() });
+    auto result = runCommand(args);
+    if (result.exitCode != 0)
+        return humaniseError("ffmpeg", result);
+    return {};
+}
+
+juce::String ffmpegConcat(const juce::File& wav1, const juce::File& wav2, const juce::File& outFile)
+{
+    auto temp = juce::File::createTempFile("concat_list.txt");
+    {
+        juce::FileOutputStream out(temp);
+        if (! out.openedOk())
+            return "Failed to create concat list";
+        out.writeText("file '" + wav1.getFullPathName() + "'\n", false, false);
+        out.writeText("file '" + wav2.getFullPathName() + "'\n", false, false);
+    }
+    auto result = runCommand({ "ffmpeg", "-y", "-loglevel", "error", "-f", "concat", "-safe", "0", "-i", temp.getFullPathName(), "-c", "copy", outFile.getFullPathName() });
+    temp.deleteFile();
+    if (result.exitCode != 0)
+        return humaniseError("ffmpeg concat", result);
+    return {};
+}
+
+juce::String stampForFilename(const juce::Time& t)
+{
+    return t.formatted("%Y%m%dT%H%M%S");
+}
+
+} // namespace
+
+} // namespace
+
+SanctSoundClient::SanctSoundClient()
+{
+    destination = juce::File::getCurrentWorkingDirectory().getChildFile("data/raw");
+    audioPrefix = "gs://noaa-passive-bioacoustic/sanctsound/audio";
+    productsPrefix = "gs://noaa-passive-bioacoustic/sanctsound/products/detections";
+}
+
+void SanctSoundClient::setDestinationDirectory(const juce::File& directory)
+{
+    destination = directory;
+}
+
+const juce::File& SanctSoundClient::getDestinationDirectory() const noexcept
+{
+    return destination;
+}
+
+juce::StringArray SanctSoundClient::siteLabels() const
+{
+    juce::StringArray labels;
+    for (auto& code : kKnownCodes)
+        labels.add(siteLabelForCode(code));
+    labels.sort(true);
+    return labels;
+}
+
+juce::String SanctSoundClient::codeForLabel(const juce::String& label) const
+{
+    return labelToCode(label);
+}
+
+std::vector<ProductGroup> SanctSoundClient::listProductGroups(const juce::String& site,
+                                                              const juce::String& tag,
+                                                              LogFn log) const
+{
+    juce::StringArray globs {
+        productsPrefix + "/" + site + "/**/*" + tag + "*.csv",
+        productsPrefix + "/" + site + "/**/*" + tag + "*.nc",
+        productsPrefix + "/" + site + "/**/*" + tag + "*.json"
+    };
+
+    std::map<juce::String, ProductGroup, std::less<>> groups;
+
+    for (auto& glob : globs)
+    {
+        log("[ls] " + glob);
+        auto result = runCommand({ "gsutil", "ls", "-r", glob });
+        if (result.exitCode != 0)
+            throw std::runtime_error(humaniseError("gsutil ls", result).toStdString());
+
+        juce::StringArray lines;
+        lines.addLines(result.output);
+        for (auto& line : lines)
+        {
+            auto url = line.trim();
+            if (! (url.startsWith("gs://") && ! url.endsWithChar('/')))
+                continue;
+            auto prefix = productsPrefix + "/" + site + "/";
+            juce::String groupName;
+            if (url.startsWithIgnoreCase(prefix))
+            {
+                auto remainder = url.substring(prefix.length());
+                groupName = remainder.upToFirstOccurrenceOf("/", false, false);
+            }
+            if (groupName.isEmpty())
+                groupName = url.fromLastOccurrenceOf("/", false, false).upToLastOccurrenceOf(".", false, false);
+
+            auto& group = groups[groupName];
+            group.name = groupName;
+            group.paths.add(url);
+            auto ext = url.fromLastOccurrenceOf(".", true, false).toLowerCase();
+            group.extCounts[ext]++;
+        }
+    }
+
+    std::vector<ProductGroup> out;
+    for (auto& kv : groups)
+        out.push_back(kv.second);
+    std::sort(out.begin(), out.end(), [](const ProductGroup& a, const ProductGroup& b) { return a.name < b.name; });
+    return out;
+}
+
+MetadataSummary SanctSoundClient::fetchMetadataSummary(const juce::String& site,
+                                                       const juce::String& group,
+                                                       juce::String& rawText,
+                                                       LogFn log) const
+{
+    auto pattern = productsPrefix + "/" + site + "/" + group + "/metadata/*.json";
+    auto result = runCommand({ "gsutil", "ls", "-r", pattern });
+    if (result.exitCode != 0)
+        throw std::runtime_error(humaniseError("gsutil ls", result).toStdString());
+
+    juce::StringArray urls;
+    for (auto& line : result.lines)
+    {
+        auto url = line.trim();
+        if (url.startsWith("gs://") && url.endsWithIgnoreCase(".json"))
+            urls.add(url);
+    }
+    urls.sort(true);
+
+    if (urls.isEmpty())
+    {
+        rawText = "(no metadata/*.json files found)";
+        return {};
+    }
+
+    juce::StringArray snippets;
+    juce::var parsed;
+
+    for (int i = 0; i < juce::jmin(2, urls.size()); ++i)
+    {
+        auto url = urls[i];
+        log("[cat] " + url);
+        auto cat = runCommand({ "gsutil", "cat", url });
+        if (cat.exitCode != 0)
+            continue;
+        auto text = cat.output.trim();
+        snippets.add("// [" + juce::String(i + 1) + "/" + juce::String(urls.size()) + "] " + url + "\n" + text);
+        if (parsed.isVoid())
+            parsed = parseJson(text);
+    }
+
+    rawText = snippets.joinIntoString("\n\n");
+    if (parsed.isVoid())
+        return {};
+
+    auto summary = buildSummaryFromJson(parsed);
+    summary.rawText = rawText;
+    return summary;
+}
+
+PreviewResult SanctSoundClient::previewGroup(const juce::String& site,
+                                             const ProductGroup& group,
+                                             bool onlyLongRuns,
+                                             LogFn log) const
+{
+    PreviewResult result;
+
+    auto mode = juce::String("EVENT");
+    auto lower = group.name.toLowerCase();
+    if (lower.endsWith("_1h"))
+        mode = "HOUR";
+    else if (lower.endsWith("_1d"))
+        mode = "DAY";
+    result.mode = mode;
+
+    auto preferredFolder = folderFromSet(group.name);
+
+    auto bestFiles = chooseBestFiles(group.paths);
+    auto downloaded = downloadFilesTo(bestFiles, destination, log);
+
+    juce::Array<juce::File> localCsvs;
+    for (auto& item : downloaded)
+        if (item.localFile.hasFileExtension("csv"))
+            localCsvs.add(item.localFile);
+
+    if (localCsvs.isEmpty())
+        throw std::runtime_error("Preview expects at least one CSV artifact");
+
+    juce::Array<PreviewWindow> windows;
+    juce::String runsText;
+    juce::String summaryText;
+    juce::Time tmin;
+    juce::Time tmax;
+
+    if (mode == "HOUR")
+    {
+        juce::Array<juce::Time> hours;
+        for (auto& csv : localCsvs)
+            hours.addArray(parsePresenceHoursFromCsv(csv));
+        hours.removeDuplicates();
+        std::sort(hours.begin(), hours.end(), [](auto& a, auto& b) { return timeLessThan(a, b); });
+
+        auto runs = groupConsecutive(hours, juce::RelativeTime::hours(1));
+        if (onlyLongRuns)
+        {
+            juce::Array<PreviewWindow> filtered;
+            for (auto& r : runs)
+                if ((r.end - r.start).inHours() >= 2.0)
+                    filtered.add(r);
+            runs = filtered;
+            hours = expandRuns(runs, juce::RelativeTime::hours(1));
+        }
+
+        windows = juce::Array<PreviewWindow>();
+        for (auto& h : hours)
+            windows.add({ h, h + juce::RelativeTime::hours(1) });
+
+        if (! hours.isEmpty())
+        {
+            tmin = hours.getFirst();
+            tmax = hours.getLast() + juce::RelativeTime::hours(1);
+        }
+
+        runsText << "Runs (" << runs.size() << "):\n";
+        int idx = 1;
+        for (auto& r : runs)
+        {
+            runsText << juce::String(idx++).paddedLeft('0', 2) << ". "
+                     << toIso(r.start) << " → " << toIso(r.end) << "\n";
+        }
+        summaryText = group.name + " | mode: hour";
+    }
+    else if (mode == "DAY")
+    {
+        juce::Array<juce::Time> days;
+        for (auto& csv : localCsvs)
+            days.addArray(parsePresenceDaysFromCsv(csv));
+        days.removeDuplicates();
+        std::sort(days.begin(), days.end(), [](auto& a, auto& b) { return timeLessThan(a, b); });
+
+        windows = juce::Array<PreviewWindow>();
+        for (auto& d : days)
+            windows.add({ d, d + juce::RelativeTime::days(1) });
+        if (! days.isEmpty())
+        {
+            tmin = days.getFirst();
+            tmax = days.getLast() + juce::RelativeTime::days(1);
+        }
+        runsText << "Days: " << days.size() << "\n";
+        summaryText = group.name + " | mode: day";
+    }
+    else
+    {
+        windows = juce::Array<PreviewWindow>();
+        for (auto& csv : localCsvs)
+            windows.addArray(parseEventsFromCsv(csv));
+        std::sort(windows.begin(), windows.end(), [](auto& a, auto& b) { return timeLessThan(a.start, b.start); });
+        if (! windows.isEmpty())
+        {
+            tmin = windows.getFirst().start;
+            tmax = windows.getLast().end;
+        }
+        runsText << "Events: " << windows.size() << "\n";
+        summaryText = group.name + " | mode: event";
+    }
+
+    auto audioFiles = listAudioFilesAcross(site, preferredFolder, tmin, tmax, audioPrefix);
+    juce::StringArray urls;
+    juce::StringArray names;
+    minimalUnionForWindows(audioFiles, windows, urls, names);
+
+    result.summary = summaryText + " | unique files: " + juce::String(names.size());
+    result.runsText = runsText;
+    result.windows = windows;
+    result.urls = urls;
+    result.names = names;
+
+    for (auto& file : audioFiles)
+    {
+        if (urls.contains(file.url))
+        {
+            ListedFile lf;
+            lf.url = file.url;
+            lf.name = file.name;
+            lf.start = file.start;
+            lf.end = file.end;
+            lf.folder = file.folder;
+            result.files.add(lf);
+        }
+    }
+
+    return result;
+}
+
+void SanctSoundClient::downloadFiles(const juce::StringArray& urls, LogFn log) const
+{
+    downloadFilesTo(urls, destination, log);
+}
+
+ClipSummary SanctSoundClient::clipGroups(const juce::Array<juce::String>& groups,
+                                         const std::map<juce::String, PreviewCache>& cache,
+                                         const juce::StringArray& selectedBasenames,
+                                         LogFn log) const
+{
+    ClipSummary summary;
+    summary.totalWindows = 0;
+    summary.written = 0;
+    summary.skipped = 0;
+
+    if (groups.isEmpty())
+        return summary;
+
+    juce::Array<LocalAudio> local;
+    juce::DirectoryIterator it(destination, false, "*.flac", juce::File::findFiles);
+    while (it.next())
+    {
+        auto file = it.getFile();
+        if (! selectedBasenames.contains(file.getFileName()))
+            continue;
+        auto startOpt = parseAudioStartFromName(file.getFileName());
+        if (! startOpt)
+            continue;
+        LocalAudio audio;
+        audio.file = file;
+        audio.name = file.getFileName();
+        audio.start = *startOpt;
+        audio.folder = folderFromSet(audio.name);
+        local.add(audio);
+    }
+
+    std::sort(local.begin(), local.end(), [](const LocalAudio& a, const LocalAudio& b)
+    {
+        return timeLessThan(a.start, b.start);
+    });
+
+    for (int i = 0; i < local.size(); ++i)
+    {
+        if (i + 1 < local.size())
+        {
+            auto end = local[i + 1].start;
+            if (! timeLessThan(local[i].start, end))
+                end = local[i].start + juce::RelativeTime::seconds(1);
+            local.getReference(i).end = end;
+        }
+        else
+        {
+            double seconds = 3600.0;
+            auto err = ffprobeDuration(local[i].file, seconds);
+            if (! err.isEmpty())
+                log("[WARN] " + err);
+            if (seconds <= 1.0)
+                seconds = 3600.0;
+            local.getReference(i).end = local[i].start + juce::RelativeTime::seconds(seconds);
+        }
+    }
+
+    auto coverAndNext = [&](const juce::Time& ts) -> std::pair<LocalAudio*, LocalAudio*>
+    {
+        LocalAudio* current = nullptr;
+        LocalAudio* next = nullptr;
+        for (int i = 0; i < local.size(); ++i)
+        {
+            if (timeLessThanOrEqual(local[i].start, ts))
+                current = &local.getReference(i);
+            else
+            {
+                next = &local.getReference(i);
+                break;
+            }
+        }
+        return { current, next };
+    };
+
+    for (auto& grp : groups)
+    {
+        auto itCache = cache.find(grp);
+        if (itCache == cache.end())
+        {
+            log("[WARN] No preview cache for " + grp);
+            continue;
+        }
+
+        const auto& preview = itCache->second;
+        summary.mode = preview.mode;
+
+        auto clipsDir = destination.getChildFile("clips").getChildFile(grp);
+        clipsDir.createDirectory();
+        summary.directory = clipsDir;
+
+        juce::Array<ClipRow> manifest;
+        int written = 0;
+        int skipped = 0;
+
+        for (auto& window : preview.windows)
+        {
+            summary.totalWindows++;
+            auto [current, next] = coverAndNext(window.start);
+            if (current == nullptr)
+            {
+                skipped++;
+                continue;
+            }
+
+            bool needTwo = timeLessThan(current->end, window.end);
+            if (! needTwo)
+            {
+                if (! selectedBasenames.contains(current->name))
+                {
+                    skipped++;
+                    continue;
+                }
+            }
+            else
+            {
+                if (next == nullptr || ! selectedBasenames.contains(current->name) || ! selectedBasenames.contains(next->name))
+                {
+                    skipped++;
+                    continue;
+                }
+            }
+
+            auto clipName = current->name.upToLastOccurrenceOf(".", false, false)
+                              + "__" + stampForFilename(window.start)
+                              + "_" + stampForFilename(window.end) + ".wav";
+            auto outFile = clipsDir.getChildFile(clipName);
+
+            auto durationSeconds = (window.end - window.start).inSeconds();
+            if (durationSeconds <= 0)
+            {
+                skipped++;
+                continue;
+            }
+
+            juce::String err;
+            if (! needTwo)
+            {
+                auto startOffset = (window.start - current->start).inSeconds();
+                err = ffmpegCut(current->file, startOffset, durationSeconds, outFile, clipSampleRate, clipMono, clipSampleFormat);
+            }
+            else
+            {
+                auto startOffset = (window.start - current->start).inSeconds();
+                auto partASeconds = (current->end - window.start).inSeconds();
+                auto partBSeconds = (window.end - next->start).inSeconds();
+                if (partASeconds <= 0 || partBSeconds <= 0)
+                {
+                    skipped++;
+                    continue;
+                }
+                auto tempA = juce::File::createTempFile("clipA.wav");
+                auto tempB = juce::File::createTempFile("clipB.wav");
+                auto errA = ffmpegCut(current->file, startOffset, partASeconds, tempA, clipSampleRate, clipMono, clipSampleFormat);
+                auto errB = ffmpegCut(next->file, 0.0, partBSeconds, tempB, clipSampleRate, clipMono, clipSampleFormat);
+                if (errA.isNotEmpty() || errB.isNotEmpty())
+                {
+                    if (errA.isNotEmpty()) log("[WARN] " + errA);
+                    if (errB.isNotEmpty()) log("[WARN] " + errB);
+                    tempA.deleteFile();
+                    tempB.deleteFile();
+                    skipped++;
+                    continue;
+                }
+                err = ffmpegConcat(tempA, tempB, outFile);
+                tempA.deleteFile();
+                tempB.deleteFile();
+            }
+
+            if (err.isNotEmpty())
+            {
+                log("[WARN] " + err);
+                outFile.deleteFile();
+                skipped++;
+                continue;
+            }
+
+            if (outFile.getSize() < 10000)
+            {
+                outFile.deleteFile();
+                skipped++;
+                continue;
+            }
+
+            ClipRow row;
+            row.clipName = outFile.getFileName();
+            row.sourceNames = needTwo ? current->name + " + " + next->name : current->name;
+            row.startIso = window.start.toISO8601(true);
+            row.endIso = window.end.toISO8601(true);
+            row.durationSeconds = durationSeconds;
+            row.mode = preview.mode;
+            manifest.add(row);
+            written++;
+        }
+
+        summary.written += written;
+        summary.skipped += skipped;
+        summary.manifestRows.addArray(manifest);
+
+        auto manifestFile = clipsDir.getChildFile("clips_manifest.csv");
+        auto writeCsvLine = [](juce::FileOutputStream& stream, const juce::StringArray& fields)
+        {
+            juce::StringArray escaped;
+            for (auto& f : fields)
+                escaped.add("\"" + f.replace("\"", "\"\"") + "\"");
+            stream.writeText(escaped.joinIntoString(",") + "\n", false, false);
+        };
+
+        {
+            juce::FileOutputStream out(manifestFile);
+            if (out.openedOk())
+            {
+                writeCsvLine(out, { "clip_wav", "source_flac(s)", "start_utc", "end_utc", "duration_sec", "mode" });
+                for (auto& row : manifest)
+                {
+                    writeCsvLine(out, {
+                        row.clipName,
+                        row.sourceNames,
+                        row.startIso,
+                        row.endIso,
+                        juce::String(row.durationSeconds, 3),
+                        row.mode
+                    });
+                }
+            }
+        }
+
+        auto summaryFile = clipsDir.getChildFile("clips_summary.txt");
+        juce::String summaryText;
+        summaryText << "Windows: " << preview.windows.size()
+                    << " | Clips: " << manifest.size()
+                    << " | Skipped: " << skipped
+                    << " | Mode: " << preview.mode << "\n"
+                    << "Dir: " << clipsDir.getFullPathName() << "\n";
+        summaryFile.replaceWithText(summaryText);
+
+        log("Clips → " + clipsDir.getFullPathName() + " | written " + juce::String(written) + ", skipped " + juce::String(skipped));
+    }
+
+    return summary;
+}
+
+} // namespace sanctsound

--- a/juce_port/Source/SanctSoundClient.h
+++ b/juce_port/Source/SanctSoundClient.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+#include <functional>
+#include <map>
+
+#include "PreviewModels.h"
+
+namespace sanctsound
+{
+struct PreviewCache
+{
+    juce::String mode;
+    juce::Array<PreviewWindow> windows;
+};
+
+class SanctSoundClient
+{
+public:
+    using LogFn = std::function<void(const juce::String&)>;
+
+    SanctSoundClient();
+
+    void setDestinationDirectory(const juce::File& directory);
+    const juce::File& getDestinationDirectory() const noexcept;
+
+    juce::StringArray siteLabels() const;
+    juce::String codeForLabel(const juce::String& label) const;
+
+    std::vector<ProductGroup> listProductGroups(const juce::String& site,
+                                                const juce::String& tag,
+                                                LogFn log) const;
+
+    MetadataSummary fetchMetadataSummary(const juce::String& site,
+                                         const juce::String& group,
+                                         juce::String& rawText,
+                                         LogFn log) const;
+
+    PreviewResult previewGroup(const juce::String& site,
+                               const ProductGroup& group,
+                               bool onlyLongRuns,
+                               LogFn log) const;
+
+    void downloadFiles(const juce::StringArray& urls, LogFn log) const;
+
+    ClipSummary clipGroups(const juce::Array<juce::String>& groups,
+                           const std::map<juce::String, PreviewCache>& cache,
+                           const juce::StringArray& selectedBasenames,
+                           LogFn log) const;
+
+private:
+    juce::File destination;
+
+    juce::String audioPrefix;
+    juce::String productsPrefix;
+
+    int clipSampleRate = 48000;
+    bool clipMono = true;
+    juce::String clipSampleFormat = "s16";
+};
+
+} // namespace sanctsound

--- a/juce_port/Source/Utilities.cpp
+++ b/juce_port/Source/Utilities.cpp
@@ -1,0 +1,158 @@
+#include "Utilities.h"
+
+#include <juce_core/juce_core.h>
+#include <stdexcept>
+
+namespace sanctsound
+{
+CommandResult runCommand(const juce::StringArray& argv)
+{
+    CommandResult result;
+    if (argv.isEmpty())
+    {
+        result.exitCode = -1;
+        result.output = "<empty command>";
+        return result;
+    }
+
+    juce::ChildProcess child;
+    if (! child.start(argv, juce::ChildProcess::wantStdOut | juce::ChildProcess::wantStdErr))
+    {
+        result.exitCode = -1;
+        result.output = "Failed to start process";
+        return result;
+    }
+
+    result.output = child.readAllProcessOutput();
+    result.lines.addLines(result.output);
+    result.exitCode = child.waitForProcessToFinish(-1);
+    return result;
+}
+
+juce::String formatCommand(const juce::StringArray& argv)
+{
+    juce::StringArray parts;
+    for (auto arg : argv)
+    {
+        if (arg.containsAnyOf(" \""))
+            parts.add("\"" + arg.replace("\"", "\\\"") + "\"");
+        else
+            parts.add(arg);
+    }
+    return parts.joinIntoString(" ");
+}
+
+juce::String humaniseError(const juce::String& context, const CommandResult& result)
+{
+    juce::String msg = context;
+    if (result.exitCode != 0)
+        msg << " failed with exit code " << result.exitCode << ".";
+    if (result.output.isNotEmpty())
+        msg << "\n" << result.output;
+    return msg;
+}
+
+bool parseTimestamp(const juce::String& text, juce::Time& out)
+{
+    auto trimmed = text.trim();
+    if (trimmed.isEmpty())
+        return false;
+
+    auto hasDigits = trimmed.containsAnyOf("0123456789");
+    if (! hasDigits)
+        return false;
+
+    auto tryIso = juce::Time::fromISO8601(trimmed);
+    if (trimmed.containsChar('-') && trimmed.containsChar(':'))
+    {
+        out = tryIso;
+        return true;
+    }
+
+    if (! trimmed.containsAnyOf("zZ"))
+    {
+        auto isoWithZ = juce::Time::fromISO8601(trimmed + "Z");
+        if (isoWithZ != juce::Time())
+        {
+            out = isoWithZ;
+            return true;
+        }
+    }
+
+    auto alt = juce::Time::fromString(trimmed, true);
+    if (alt != juce::Time())
+    {
+        out = alt;
+        return true;
+    }
+
+    return false;
+}
+
+juce::String toIso(const juce::Time& time)
+{
+    return time.toISO8601(true);
+}
+
+juce::StringArray splitCsvLine(const juce::String& line)
+{
+    juce::StringArray fields;
+    juce::String current;
+    bool inQuotes = false;
+
+    auto len = line.length();
+    for (int i = 0; i < len; ++i)
+    {
+        auto ch = line[i];
+        if (ch == '"')
+        {
+            if (inQuotes && i + 1 < len && line[i + 1] == '"')
+            {
+                current << '"';
+                ++i;
+            }
+            else
+            {
+                inQuotes = ! inQuotes;
+            }
+            continue;
+        }
+
+        if (ch == ',' && ! inQuotes)
+        {
+            fields.add(current.trim());
+            current.clear();
+            continue;
+        }
+
+        current << ch;
+    }
+
+    fields.add(current.trim());
+    for (auto& f : fields)
+        f = f.trim().unquoted();
+    return fields;
+}
+
+CsvTable readCsvFile(const juce::File& file)
+{
+    CsvTable table;
+    juce::FileInputStream stream(file);
+    if (! stream.openedOk())
+        throw std::runtime_error("Failed to open CSV: " + file.getFullPathName().toStdString());
+
+    auto content = stream.readEntireStreamAsString();
+    juce::StringArray lines;
+    lines.addLines(content);
+    lines.removeEmptyStrings(true);
+
+    if (lines.isEmpty())
+        return table;
+
+    table.header = splitCsvLine(lines.removeAndReturn(0));
+    for (auto& line : lines)
+        table.rows.add(splitCsvLine(line));
+    return table;
+}
+
+} // namespace sanctsound

--- a/juce_port/Source/Utilities.h
+++ b/juce_port/Source/Utilities.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+namespace sanctsound
+{
+struct CommandResult
+{
+    int exitCode = -1;
+    juce::String output;
+    juce::StringArray lines;
+};
+
+CommandResult runCommand(const juce::StringArray& argv);
+
+juce::String formatCommand(const juce::StringArray& argv);
+
+juce::String humaniseError(const juce::String& context, const CommandResult& result);
+
+bool parseTimestamp(const juce::String& text, juce::Time& out);
+
+juce::String toIso(const juce::Time& time);
+
+struct CsvTable
+{
+    juce::StringArray header;
+    juce::Array<juce::StringArray> rows;
+};
+
+CsvTable readCsvFile(const juce::File& file);
+
+juce::StringArray splitCsvLine(const juce::String& line);
+
+} // namespace sanctsound


### PR DESCRIPTION
## Summary
- add a JUCE-based GUI scaffold with list, metadata, logging, and status components
- port SanctSound client logic for listing, previewing, downloading, and clipping data
- document build instructions for the JUCE target

## Testing
- not run (JUCE SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc169a0c68833293198581f286938d