### PR TITLE
Fix JUCE API updates

### DIFF
--- a/juce_port/Source/MetadataView.cpp
+++ b/juce_port/Source/MetadataView.cpp
@@ -93,7 +93,7 @@ MetadataView::MetadataView()
     addAndMakeVisible(titleLabel);
     titleLabel.setText("Metadata", juce::dontSendNotification);
     titleLabel.setJustificationType(juce::Justification::left);
-    titleLabel.setFont(juce::Font(16.0f, juce::Font::bold));
+    titleLabel.setFont(juce::FontOptions(16.0f, juce::Font::bold));
 
     summaryTab = std::make_unique<SummaryPanel>(messageLabel,
                                                 siteValue,
@@ -111,7 +111,7 @@ MetadataView::MetadataView()
     rawEditor.setMultiLine(true, true);
     rawEditor.setReadOnly(true);
     rawEditor.setScrollbarsShown(true, true);
-    rawEditor.setFont(juce::Font(13.0f));
+    rawEditor.setFont(juce::FontOptions(13.0f));
     rawEditor.setTextToShowWhenEmpty("Select a set to view metadata.", juce::Colours::grey);
     tabs.addTab("Raw JSON", juce::Colours::transparentBlack, &rawEditor, false);
 
@@ -133,7 +133,7 @@ void MetadataView::initialiseSummaryCards()
     auto configureValue = [](juce::Label& label)
     {
         label.setJustificationType(juce::Justification::left);
-        label.setFont(juce::Font(14.0f));
+        label.setFont(juce::FontOptions(14.0f));
         label.setColour(juce::Label::textColourId, juce::Colours::black);
         label.setBorderSize(juce::BorderSize<int>(2));
         label.setMinimumHorizontalScale(0.6f);
@@ -145,7 +145,7 @@ void MetadataView::initialiseSummaryCards()
         label->setText(title, juce::dontSendNotification);
         label->setJustificationType(juce::Justification::left);
         label->setColour(juce::Label::textColourId, juce::Colours::darkgrey);
-        label->setFont(juce::Font(12.5f, juce::Font::bold));
+        label->setFont(juce::FontOptions(12.5f, juce::Font::bold));
         summaryTab->addAndMakeVisible(label.get());
         titleLabels.push_back(std::move(label));
 


### PR DESCRIPTION
## Summary
- replace deprecated Font constructors in MetadataView with the new FontOptions helper
- adjust SanctSoundClient to the current JUCE API (optional dereference, OutputStream::writeText signature change, and range handling)
- add a helper for removing duplicate juce::Time entries without relying on removed Array::removeDuplicates

## Testing
- cmake -B build -S juce_port *(fails: missing X11 headers in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68cc640dbb008332ad893ee8408bd3f8