### PR TITLE
Add headless JUCE CLI build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.19)
+project(SanctSound LANGUAGES C CXX)
+
+add_subdirectory(juce_port)

--- a/juce_port/CMakeLists.txt
+++ b/juce_port/CMakeLists.txt
@@ -9,6 +9,11 @@ option(SANCTSOUND_HEADLESS "Build without JUCE GUI (for CI/Codex Linux)" OFF)
 # JUCE vendored
 set(JUCE_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(JUCE_BUILD_EXTRAS   OFF CACHE BOOL "" FORCE)
+if (SANCTSOUND_HEADLESS)
+    # Avoid building juceaide (and GUI/X11 dependencies) when we only need
+    # the JUCE modules for the command-line target.
+    set(JUCE_MODULES_ONLY ON CACHE BOOL "" FORCE)
+endif()
 add_subdirectory(external/JUCE)
 
 # Common sources (non-GUI)
@@ -28,11 +33,15 @@ if (SANCTSOUND_HEADLESS)
     target_link_libraries(SanctSoundCli PRIVATE
         juce::juce_core
         juce::juce_data_structures
-        juce::juce_events
-        juce::juce_audio_basics
-        juce::juce_audio_devices
-        juce::juce_dsp
-        # ^ keep only non-GUI modules
+    )
+    find_package(CURL REQUIRED)
+    target_link_libraries(SanctSoundCli PRIVATE CURL::libcurl)
+    set_target_properties(SanctSoundCli PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}"
+        RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}"
+        RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL "${CMAKE_BINARY_DIR}"
     )
 else()
     # ---- Full GUI app for macOS/local ----

--- a/juce_port/Source/cli_main.cpp
+++ b/juce_port/Source/cli_main.cpp
@@ -1,5 +1,4 @@
 #include <juce_core/juce_core.h>
-#include <juce_audio_basics/juce_audio_basics.h>
 #include "SanctSoundClient.h"
 #include "PreviewModels.h"
 #include "Utilities.h"


### PR DESCRIPTION
## Summary
- add a root CMakeLists.txt so the project configures from the repository root
- update the headless CLI target to avoid JUCE GUI tooling, link libcurl, and drop unused audio modules
- refresh timestamp parsing utilities for JUCE 8 APIs and keep the CLI minimal

## Testing
- cmake -S . -B build -DSANCTSOUND_HEADLESS=ON -DCMAKE_BUILD_TYPE=Release
- cmake --build build --config Release
- ./build/SanctSoundCli

------
https://chatgpt.com/codex/tasks/task_e_68cc6d8fb4088332995e10b874268c2a