### PR TITLE
Use RangedDirectoryIterator when scanning local audio files

### DIFF
--- a/juce_port/Source/SanctSoundClient.cpp
+++ b/juce_port/Source/SanctSoundClient.cpp
@@ -1006,10 +1006,9 @@ ClipSummary SanctSoundClient::clipGroups(const juce::Array<juce::String>& groups
         return summary;
 
     juce::Array<LocalAudio> local;
-    juce::DirectoryIterator it(destination, false, "*.flac", juce::File::findFiles);
-    while (it.next())
+    for (const auto& entry : juce::RangedDirectoryIterator(destination, false, "*.flac", juce::File::findFiles))
     {
-        auto file = it.getFile();
+        auto file = entry.getFile();
         if (! selectedBasenames.contains(file.getFileName()))
             continue;
         auto startOpt = parseAudioStartFromName(file.getFileName());


### PR DESCRIPTION
## Summary
- replace the deprecated `DirectoryIterator` with `RangedDirectoryIterator` when enumerating downloaded audio files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc8031ff5c8332beb065eea65445aa