### PR TITLE
Handle empty gsutil matches and improve font fallback

### DIFF
--- a/juce_port/Source/Main.cpp
+++ b/juce_port/Source/Main.cpp
@@ -9,6 +9,8 @@ juce::String chooseUIFont()
 
 #if JUCE_MAC
     preferred.add("SF Pro Text");
+    preferred.add(".SF NS Text");
+    preferred.add(".AppleSystemUIFont");
     preferred.add("Helvetica Neue");
     preferred.add("Avenir Next");
     preferred.add("Helvetica");
@@ -26,16 +28,20 @@ juce::String chooseUIFont()
     preferred.add("Arial");
 #endif
 
-    auto available = juce::Font::findAllTypefaceNames();
+    auto available   = juce::Font::findAllTypefaceNames();
+    auto defaultName = juce::Font::getDefaultSansSerifFontName();
 
     for (auto& name : preferred)
         if (available.contains(name))
             return name;
 
+    if (available.contains(defaultName))
+        return defaultName;
+
     if (! available.isEmpty())
         return available[0];
 
-    return juce::Font::getDefaultSansSerifFontName();
+    return defaultName;
 }
 } // namespace
 


### PR DESCRIPTION
## Summary
- treat `gsutil ls` "no matches" responses as an empty result instead of an error, while logging the lack of matches
- expand the preferred macOS font list and fall back to the system default sans-serif font before picking the first available family

## Testing
- cmake -S semi -B semi/build -DSANCTSOUND_HEADLESS=ON
- cmake --build semi/build

------
https://chatgpt.com/codex/tasks/task_e_68cc86d69bf4833286e5256a1ccb93f5