### PR TITLE
Handle empty gsutil listings gracefully

### DIFF
--- a/sanctsound_gui/audio_listing.py
+++ b/sanctsound_gui/audio_listing.py
@@ -9,7 +9,7 @@ from .timeparse import parse_audio_start_from_name, parse_audio_start_from_url
 def list_site_deployments(site: str) -> list[str]:
     base = f"{AUDIO_PREFIX}/{site}/"
     folders = []
-    for line in run_cmd(["gsutil", "ls", base]):
+    for line in run_cmd(["gsutil", "ls", base], ok_returncodes=(0, 1)):
         if line.strip().endswith("/"):
             name = line.strip().split("/")[-2]
             if name.startswith("sanctsound_"):
@@ -31,7 +31,7 @@ def list_audio_files_in_folder(site: str, folder: str, tmin, tmax):
     pat = f"{AUDIO_PREFIX}/{site}/{folder}/audio/*.flac"
     rows = []
     left_candidate = None
-    for line in run_cmd(["gsutil", "ls", "-r", pat]):
+    for line in run_cmd(["gsutil", "ls", "-r", pat], ok_returncodes=(0, 1)):
         if not (line.startswith("gs://") and line.lower().endswith(".flac")):
             continue
         url = line.strip()

--- a/sanctsound_gui/gui/app.py
+++ b/sanctsound_gui/gui/app.py
@@ -143,7 +143,7 @@ def label_to_code(label: str) -> str:
 def _gcs_ls_metadata_jsons(site: str, group: str, log_cb) -> List[str]:
     pat = f"{PRODUCTS_PREFIX}/{site}/{group}/metadata/*.json"
     out=[]
-    for line in run_cmd(["gsutil","ls","-r",pat]):
+    for line in run_cmd(["gsutil","ls","-r",pat], ok_returncodes=(0, 1)):
         s=line.strip()
         if s.startswith("gs://") and s.lower().endswith(".json"):
             out.append(s)

--- a/sanctsound_gui/metadata.py
+++ b/sanctsound_gui/metadata.py
@@ -122,7 +122,7 @@ def _discover_sites(verbose: bool) -> List[str]:
 
     if verbose:
         print(f"[sites] ls {base}", flush=True)
-    for line in run_cmd(["gsutil", "ls", base]):
+    for line in run_cmd(["gsutil", "ls", base], ok_returncodes=(0, 1)):
         s = line.strip()
         m = SITE_RE.search(s)
         if m:
@@ -132,7 +132,7 @@ def _discover_sites(verbose: bool) -> List[str]:
         pat = f"{PRODUCTS_PREFIX}/**"
         if verbose:
             print(f"[sites-fallback] ls -r {pat}", flush=True)
-        for line in run_cmd(["gsutil", "ls", "-r", pat]):
+        for line in run_cmd(["gsutil", "ls", "-r", pat], ok_returncodes=(0, 1)):
             s = line.strip()
             if not s.startswith("gs://"):
                 continue
@@ -157,7 +157,7 @@ def _scan_site_objects(site: str, verbose: bool) -> Tuple[Dict[str, List[str]], 
     pat = f"{PRODUCTS_PREFIX}/{site}/**"
     if verbose:
         print(f"[{site}] ls -r {pat}", flush=True)
-    for line in run_cmd(["gsutil", "ls", "-r", pat]):
+    for line in run_cmd(["gsutil", "ls", "-r", pat], ok_returncodes=(0, 1)):
         s = line.strip()
         if not s.startswith("gs://"):
             continue

--- a/sanctsound_gui/products.py
+++ b/sanctsound_gui/products.py
@@ -41,7 +41,7 @@ def list_product_groups(site: str, tag: str, log_cb: Optional[Callable[[str], No
 
     for g in globs:
         _log(log_cb, f"[ls] {g}")
-        for line in run_cmd(["gsutil", "ls", "-r", g]):
+        for line in run_cmd(["gsutil", "ls", "-r", g], ok_returncodes=(0, 1)):
             url = line.strip()
             if not (url.startswith("gs://") and not url.endswith("/")):
                 continue


### PR DESCRIPTION
## Summary
- allow run_cmd to accept additional successful return codes
- treat gsutil ls commands as successful even when no objects match
- prevent the GUI from crashing when product or metadata listings are empty

## Testing
- python -m compileall sanctsound_gui

------
https://chatgpt.com/codex/tasks/task_e_68cc8ce622e88332919c27e206b4e5bf