### PR TITLE
Replace gsutil usage with direct GCS API and clean UI text

### DIFF
--- a/juce_port/Source/Main.cpp
+++ b/juce_port/Source/Main.cpp
@@ -47,7 +47,7 @@ juce::String chooseUIFont()
 
 // NOTE: Your MainComponent is inside namespace `sanctsound`.
 // Either qualify it here, or `using namespace sanctsound;`.
-// We’ll fully qualify to avoid namespace leaks.
+// We'll fully qualify to avoid namespace leaks.
 
 class MainWindow : public juce::DocumentWindow
 {

--- a/juce_port/Source/MainComponent.cpp
+++ b/juce_port/Source/MainComponent.cpp
@@ -30,7 +30,7 @@ juce::String formatExtCounts(const ProductGroup& group)
     return parts.joinIntoString(", ");
 }
 
-// Convert juce::StringArray → juce::Array<juce::String>
+// Convert juce::StringArray -> juce::Array<juce::String>
 static juce::Array<juce::String> toArray(const juce::StringArray& sa)
 {
     juce::Array<juce::String> a;
@@ -151,7 +151,7 @@ public:
             nameLabel.setText(entry->file.name, juce::dontSendNotification);
 
             juce::String times;
-            times << entry->file.start.toISO8601(true) << " → " << entry->file.end.toISO8601(true);
+            times << entry->file.start.toISO8601(true) << " -> " << entry->file.end.toISO8601(true);
             timeLabel.setText(times, juce::dontSendNotification);
 
             urlLabel.setText(entry->file.url, juce::dontSendNotification);
@@ -277,14 +277,14 @@ MainComponent::MainComponent()
 
     tagEditor.setText("dolphin");
     tagEditor.setTextToShowWhenEmpty("dolphin", juce::Colours::grey);
-    onlyLongRunsToggle.setButtonText("Only runs ≥ 2h");
+    onlyLongRunsToggle.setButtonText("Only runs >= 2h");
     refreshButton.setButtonText("Refresh");
     listButton.setButtonText("List sets");
     previewButton.setButtonText("Preview");
     downloadButton.setButtonText("Download");
     clipButton.setButtonText("Clip");
-    chooseDestButton.setButtonText("Choose…");
-    logButton.setButtonText("Log…");
+    chooseDestButton.setButtonText("Choose...");
+    logButton.setButtonText("Log...");
 
     previewButton.setEnabled(false);
     downloadButton.setEnabled(false);
@@ -383,7 +383,7 @@ void MainComponent::handleListSets()
     auto site = client.codeForLabel(siteCombo.getText());
     auto tag  = tagEditor.getText().trim();
 
-    setStatus("Listing sets…");
+    setStatus("Listing sets...");
     listButton.setEnabled(false);
     previewButton.setEnabled(false);
     downloadButton.setEnabled(false);
@@ -445,7 +445,7 @@ void MainComponent::handlePreview()
         if (entry.selected) groupsToPreview.push_back(entry.group);
     if (groupsToPreview.empty()) return;
 
-    setStatus("Previewing…");
+    setStatus("Previewing...");
     previewButton.setEnabled(false);
     downloadButton.setEnabled(false);
     clipButton.setEnabled(false);
@@ -498,7 +498,7 @@ void MainComponent::handleDownload()
         return;
     }
 
-    setStatus("Downloading files…");
+    setStatus("Downloading files...");
     downloadButton.setEnabled(false);
 
     runInBackground([this, urls]()
@@ -544,7 +544,7 @@ void MainComponent::handleClip()
         return;
     }
 
-    setStatus("Clipping…");
+    setStatus("Clipping...");
     clipButton.setEnabled(false);
 
     auto selectedArr  = toArray(selected);
@@ -649,7 +649,7 @@ void MainComponent::onGroupInfo(int index)
     auto site      = client.codeForLabel(siteCombo.getText());
     auto groupName = groups[(size_t)index].group.name;
     metadataView.setGroupTitle(groupName);
-    metadataView.showMessage("Loading metadata…");
+    metadataView.showMessage("Loading metadata...");
 
     runInBackground([this, site, groupName]()
     {

--- a/juce_port/Source/MetadataView.cpp
+++ b/juce_port/Source/MetadataView.cpp
@@ -177,7 +177,7 @@ void MetadataView::setSummary(const MetadataSummary& summary)
     auto setValue = [](juce::Label& label, const juce::String& text)
     {
         auto trimmed = text.trim();
-        label.setText(trimmed.isNotEmpty() ? trimmed : juce::String("—"),
+        label.setText(trimmed.isNotEmpty() ? trimmed : juce::String("-"),
                       juce::dontSendNotification);
         label.setVisible(true);
     };
@@ -209,7 +209,7 @@ void MetadataView::showMessage(const juce::String& message)
 
     auto hideValue = [](juce::Label& label)
     {
-        label.setText("—", juce::dontSendNotification);
+        label.setText("-", juce::dontSendNotification);
         label.setVisible(false);
     };
 

--- a/juce_port/Source/MetadataView.h
+++ b/juce_port/Source/MetadataView.h
@@ -12,7 +12,7 @@ class MetadataView : public juce::Component
 {
 public:
     MetadataView();
-    ~MetadataView(); // <— out-of-line dtor so unique_ptr<SummaryPanel> is destroyed with full type
+    ~MetadataView(); // <- out-of-line dtor so unique_ptr<SummaryPanel> is destroyed with full type
 
     void setGroupTitle(const juce::String& groupName);
     void setSummary(const MetadataSummary& summary);
@@ -36,7 +36,7 @@ private:
 
     std::vector<std::unique_ptr<juce::Label>> titleLabels;
 
-    // “Value” labels placed inside SummaryPanel
+    // "Value" labels placed inside SummaryPanel
     juce::Label siteValue;
     juce::Label deploymentValue;
     juce::Label platformValue;

--- a/juce_port/Source/SanctSoundClient.h
+++ b/juce_port/Source/SanctSoundClient.h
@@ -49,8 +49,13 @@ public:
                            LogFn log) const;
 
 private:
+    static juce::var fetchGcsJson(const juce::String& bucket,
+                                  const juce::String& prefix,
+                                  const juce::String& delimiter = "/");
+
     juce::File destination;
 
+    juce::String gcsBucket;
     juce::String audioPrefix;
     juce::String productsPrefix;
 

--- a/juce_port/Source/cli_main.cpp
+++ b/juce_port/Source/cli_main.cpp
@@ -12,7 +12,7 @@ int main()
     try
     {
         sanctsound::SanctSoundClient client;
-        // Do a light sanity check that doesn’t hit GUI or network-only paths
+        // Do a light sanity check that doesn't hit GUI or network-only paths
         // (Adjust to whatever is safe in Codex)
         auto labels = client.siteLabels(); // if this is static; otherwise just log
         Logger::writeToLog("Sites: " + String(labels.size()));


### PR DESCRIPTION
## Summary
- replace gsutil command execution with direct Google Cloud Storage JSON API calls and HTTPS downloads, including a reusable fetch helper and bucket member on SanctSoundClient
- update product, metadata, and audio listing logic to walk JSON prefixes/items and keep logging output ASCII-safe
- replace non-ASCII UI strings and comments in the JUCE frontend to avoid mojibake

## Testing
- `cmake -S . -B build` *(fails: missing X11/Xrandr headers in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9068436c8332a447bc34623d2057