### PR TITLE
Ensure writable default destination and safe file writes

### DIFF
--- a/juce_port/Source/MainComponent.cpp
+++ b/juce_port/Source/MainComponent.cpp
@@ -369,7 +369,12 @@ void MainComponent::buttonClicked(juce::Button* button)
         juce::FileChooser chooser("Choose destination", client.getDestinationDirectory());
         if (chooser.browseForDirectory())
         {
-            client.setDestinationDirectory(chooser.getResult());
+            if (! client.setDestinationDirectory(chooser.getResult()))
+            {
+                juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::WarningIcon,
+                    "Folder error", "Cannot use the selected folder. Check permissions.");
+                return;
+            }
             destinationLabel.setText(chooser.getResult().getFullPathName(), juce::dontSendNotification);
         }
     }

--- a/juce_port/Source/SanctSoundClient.h
+++ b/juce_port/Source/SanctSoundClient.h
@@ -21,8 +21,8 @@ public:
 
     SanctSoundClient();
 
-    void setDestinationDirectory(const juce::File& directory);
-    const juce::File& getDestinationDirectory() const noexcept;
+    bool setDestinationDirectory(const juce::File& directory);
+    const juce::File& getDestinationDirectory() const;
 
     juce::StringArray siteLabels() const;
     juce::String codeForLabel(const juce::String& label) const;
@@ -49,7 +49,7 @@ public:
                            LogFn log) const;
 
 private:
-    juce::File destination;
+    juce::File destinationDir;
 
     juce::String gcsBucket;
     juce::String audioPrefix;


### PR DESCRIPTION
## Summary
- set the SanctSoundClient default destination to `~/Documents/SanctSound`, ensure directory creation succeeds, and add helpers that guard file writes
- harden download, clip manifest, and summary writing by creating parent folders, checking FileOutputStream status, and throwing detailed runtime errors
- surface destination-folder selection failures in MainComponent so the UI alerts users when a directory cannot be used

## Testing
- cmake -S . -B build *(fails: missing X11 headers such as Xrandr)*
- cmake --build build --config Release *(fails: configure did not complete so no Makefile was generated)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ac57edc88332b86700c9296825b8