### PR TITLE
Implement JUCE-based clipping and improve status messaging

### DIFF
--- a/juce_port/CMakeLists.txt
+++ b/juce_port/CMakeLists.txt
@@ -33,6 +33,8 @@ if (SANCTSOUND_HEADLESS)
     target_link_libraries(SanctSoundCli PRIVATE
         juce::juce_core
         juce::juce_data_structures
+        juce::juce_audio_basics
+        juce::juce_audio_formats
     )
     find_package(CURL REQUIRED)
     target_link_libraries(SanctSoundCli PRIVATE CURL::libcurl)
@@ -84,6 +86,7 @@ else()
         juce::juce_audio_basics
         juce::juce_audio_devices
         juce::juce_audio_utils
+        juce::juce_audio_formats
         juce::juce_dsp
     )
 

--- a/juce_port/Source/PreviewModels.h
+++ b/juce_port/Source/PreviewModels.h
@@ -56,11 +56,13 @@ struct PreviewResult
 struct ClipRow
 {
     juce::String clipName;
+    juce::String writtenPath;
     juce::String sourceNames;
     juce::String startIso;
     juce::String endIso;
     double durationSeconds = 0.0;
     juce::String mode;
+    juce::String status;
 };
 
 struct ClipSummary


### PR DESCRIPTION
## Summary
- link the JUCE audio formats/basics modules into both CLI and GUI builds
- replace the ffmpeg-based clipper with a JUCE AudioFormat pipeline that reads, writes, and logs per-window status
- extend clip manifests with status and written path columns and adjust the summary dialog when no clips are produced

## Testing
- cmake --build build --config Release

------
https://chatgpt.com/codex/tasks/task_e_68d2b73fce308332928efa319697a074