### PR TITLE
Fix audio listing for SanctSound preview and CLI

### DIFF
--- a/juce_port/Source/SanctSoundClient.h
+++ b/juce_port/Source/SanctSoundClient.h
@@ -3,6 +3,8 @@
 #include <juce_core/juce_core.h>
 #include <functional>
 #include <map>
+#include <utility>
+#include <vector>
 
 #include "PreviewModels.h"
 
@@ -18,6 +20,17 @@ class SanctSoundClient
 {
 public:
     using LogFn = std::function<void(const juce::String&)>;
+
+    struct AudioListingResult
+    {
+        juce::String prefix;
+        int totalListed = 0;
+        std::vector<juce::String> uniqueObjects;
+        juce::StringArray sampleAll;
+        juce::StringArray sampleKept;
+        juce::StringArray sampleDropped;
+        std::vector<std::pair<juce::String, juce::String>> droppedPairs;
+    };
 
     SanctSoundClient();
 
@@ -40,6 +53,12 @@ public:
                                const ProductGroup& group,
                                bool onlyLongRuns,
                                LogFn log) const;
+
+    AudioListingResult listAudioObjectsForGroup(const juce::String& site,
+                                                const juce::String& groupName,
+                                                LogFn log) const;
+
+    void writeAudioListingDebugFiles(const AudioListingResult& listing) const;
 
     void downloadFiles(const juce::StringArray& urls, LogFn log) const;
 


### PR DESCRIPTION
## Summary
- tighten audio object listing to target the exact group prefix and reuse it across preview and CLI paths
- add robust dedupe and diagnostics (including debug files and detailed logging) for preview selection parity
- extend the headless CLI to dump listing details for sanctsound_ci01_02_bluewhale and emit the new diagnostics

## Testing
- `cmake -S juce_port -B build -DSANCTSOUND_HEADLESS=ON -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --config Release`
- `./build/SanctSoundCli` *(fails in this environment: GCS list request cannot connect)*

------
https://chatgpt.com/codex/tasks/task_e_68d2de2aad5c8332bf8964bbe8f9855e