### PR TITLE
Clean up duplicate clipGroups and fix helper wiring

### DIFF
--- a/juce_port/Source/SanctSoundClient.h
+++ b/juce_port/Source/SanctSoundClient.h
@@ -76,6 +76,38 @@ public:
                            LogFn log) const;
 
 private:
+    struct HourRow
+    {
+        juce::String url;
+        juce::String fname;
+        juce::Time start;
+        juce::Time end;
+        juce::String folder;
+    };
+
+    static bool parseTimeUTC(const juce::String& text, juce::Time& out);
+    static juce::Optional<juce::Time> parseAudioStartFromName(const juce::String& name);
+    static juce::String folderFromSet(const juce::String& setName);
+    static std::vector<HourRow> buildHoursFromRows(std::vector<HourRow> rows);
+    static std::pair<juce::StringArray, juce::StringArray> minimalUnionForWindows(const std::vector<HourRow>& files,
+                                                                                 const std::vector<std::pair<juce::Time, juce::Time>>& windows,
+                                                                                 juce::StringArray& mappingRows);
+
+    std::vector<std::pair<juce::Time, juce::Time>> parseEventsFromCsv(const juce::File& localCsv) const;
+    std::vector<juce::Time> parsePresenceHoursFromCsv(const juce::File& localCsv) const;
+    std::vector<juce::Time> parsePresenceDaysFromCsv(const juce::File& localCsv) const;
+    std::vector<juce::String> listSiteDeployments(const juce::String& site, LogFn log) const;
+    std::vector<HourRow> listAudioFilesInFolder(const juce::String& site,
+                                                const juce::String& folder,
+                                                const juce::Time& tmin,
+                                                const juce::Time& tmax,
+                                                LogFn log) const;
+    std::vector<HourRow> listAudioFilesAcross(const juce::String& site,
+                                              const juce::String& preferredFolder,
+                                              const juce::Time& tmin,
+                                              const juce::Time& tmax,
+                                              LogFn log) const;
+
     juce::File destinationDir;
 
     juce::String gcsBucket;
@@ -85,6 +117,7 @@ private:
     int clipSampleRate = 48000;
     bool clipMono = true;
     juce::String clipSampleFormat = "s16";
+    int clipMinBytes = 10000;
 
     juce::File offlineDataRoot;
     bool offlineEnabled = false;


### PR DESCRIPTION
## Summary
- remove the duplicate `clipGroups` implementation so only the ffmpeg-based pipeline remains
- refactor helper functions to use internal `parseTimeUTCImpl`/`parseAudioStartFromNameImpl` wrappers accessible to free helpers
- normalise presence hour/day parsing by truncating via milliseconds instead of unavailable UTC getters

## Testing
- cmake -S . -B build *(fails: missing X11 headers when building juceaide)*
- cmake -S . -B build -DSANCTSOUND_HEADLESS=ON
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68d3027a491c8332af8a2f996cbc7c4f