### PR TITLE
Improve SanctSound preview gsutil listings

### DIFF
--- a/juce_port/Source/SanctSoundClient.h
+++ b/juce_port/Source/SanctSoundClient.h
@@ -81,9 +81,9 @@ private:
     {
         juce::String url;
         juce::String fname;
+        juce::String folder;
         juce::Time   startUTC;
         juce::Time   endUTC;
-        juce::String folder;
     };
 
     static bool parseTimeUTC(const juce::String& text, juce::Time& out);
@@ -98,7 +98,9 @@ private:
                                                 const juce::String& folder,
                                                 juce::Optional<juce::Time> tmin,
                                                 juce::Optional<juce::Time> tmax,
-                                                const std::function<void(const juce::String&)>& log) const;
+                                                const std::function<void(const juce::String&)>& log,
+                                                juce::String* commandOut = nullptr,
+                                                juce::StringArray* linesOut = nullptr) const;
     static void buildHoursFromRows(std::vector<HourRow>& rows);
     std::vector<HourRow> listAudioFilesAcross(const juce::String& site,
                                               const juce::String& preferredFolder,


### PR DESCRIPTION
## Summary
- use juce::RegExp helpers for audio timestamp parsing and deployment folder detection
- switch deployment and audio scans to `gsutil ls`, logging counts, skips and left-boundary selections
- capture raw listing output for empty previews and log site/folder/time window diagnostics

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release *(fails: X11/extensions/Xrandr.h missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d42586fc448332a25fb39d25698823