### PR TITLE
Improve macOS build configuration and diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,24 @@
 cmake_minimum_required(VERSION 3.19)
 project(SanctSound LANGUAGES C CXX)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Release by default unless generator supplies one
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
+endif()
+
+# macOS baseline so users with older SDKs can run the app
+set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0")
+
+# Clang warnings: helpful, but don’t fail on deprecations
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
+  add_compile_options(
+    -Wall -Wextra -Wpedantic
+    -Wno-deprecated-declarations
+    -Wno-unknown-pragmas
+  )
+endif()
+
 add_subdirectory(juce_port)


### PR DESCRIPTION
## Summary
- add CMake defaults for macOS builds, including C++17, Release mode, deployment target, and Clang warning tuning
- provide a portable UTC helper and switch regex parsing to std::regex in SanctSoundClient
- expand gsutil diagnostics so zero-results cases report the command, counts, and sample output

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release *(fails: missing X11/extensions/Xrandr.h in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d43601a16083329614cd0968f88264