### PR TITLE
Add headless CLI and share parsing helpers

### DIFF
--- a/juce_port/CMakeLists.txt
+++ b/juce_port/CMakeLists.txt
@@ -16,6 +16,12 @@ if (SANCTSOUND_HEADLESS)
 endif()
 add_subdirectory(external/JUCE)
 
+# Headless / CLI build switch (safe in containers)
+option(SANCTSOUND_BUILD_CLI "Build a headless CLI target for container tests" ON)
+if (SANCTSOUND_BUILD_CLI)
+  add_subdirectory(cli)
+endif()
+
 # Common sources (non-GUI)
 set(SANCT_CORE_SOURCES
     Source/SanctSoundClient.cpp

--- a/juce_port/Source/SanctSoundClient.h
+++ b/juce_port/Source/SanctSoundClient.h
@@ -77,13 +77,19 @@ public:
                            const juce::StringArray& selectedBasenames,
                            LogFn log) const;
 
+    // === Parsing helpers (public, used by GUI & CLI) ===
+    static bool parseAudioStartFromName(const juce::String& filename, juce::Time& outUTC);
+    /** Returns "sanctsound_ci01_02" from "sanctsound_ci01_02_*" (lowercased),
+        or empty string if no match. */
+    static juce::String folderFromSetName(const juce::String& setName);
+
+    friend struct AudioHourSorter;
+
 private:
     static bool parseTimeUTC(const juce::String& text, juce::Time& out);
     static std::vector<std::pair<juce::Time, juce::Time>> parseEventsFromCsv(const juce::File& localCsv);
     static std::vector<juce::Time> parsePresenceHoursFromCsv(const juce::File& localCsv);
     static std::vector<juce::Time> parsePresenceDaysFromCsv(const juce::File& localCsv);
-    static juce::String folderFromSet(const juce::String& setName);
-    static bool parseAudioStartFromName(const juce::String& name, juce::Time& outUTC);
     struct AudioHour
     {
         juce::URL url;

--- a/juce_port/cli/CMakeLists.txt
+++ b/juce_port/cli/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.19)
+
+# If the top-level already added JUCE via add_subdirectory(external/JUCE), we don't repeat it here.
+
+if (NOT COMMAND juce_add_console_app)
+    include(${JUCE_SOURCE_DIR}/extras/Build/CMake/JUCEUtils.cmake)
+endif()
+
+juce_add_console_app(sanctsound_cli
+    PRODUCT_NAME "SanctSound CLI"
+)
+
+target_sources(sanctsound_cli PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/main_cli.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/../Source/SanctSoundClient.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/../Source/Utilities.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/../Source/PreviewModels.cpp
+)
+
+target_include_directories(sanctsound_cli PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/../Source
+)
+
+# Link only non-GUI JUCE modules to avoid X11/WebKit
+target_link_libraries(sanctsound_cli PRIVATE
+    juce::juce_core
+    juce::juce_data_structures
+    juce::juce_events
+)
+
+target_compile_definitions(sanctsound_cli PRIVATE
+    JUCE_WEB_BROWSER=0
+    JUCE_USE_XRANDR=0
+    JUCE_USE_CURL=0
+    JUCE_DISPLAY_SPLASH_SCREEN=0
+    JUCE_MODAL_LOOPS_PERMITTED=0
+)

--- a/juce_port/cli/main_cli.cpp
+++ b/juce_port/cli/main_cli.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include "SanctSoundClient.h"
+
+int main()
+{
+    using sanctsound::SanctSoundClient;
+
+    juce::Time ts;
+    const juce::String f1 = "SanctSound_CI01_02_20190624T120000Z.flac";
+    const juce::String f2 = "SanctSound_CI01_02_190624120000.flac";
+    const juce::String set = "sanctsound_ci01_02_bluewhale";
+
+    const bool ok1 = SanctSoundClient::parseAudioStartFromName(f1, ts);
+    const bool ok2 = SanctSoundClient::parseAudioStartFromName(f2, ts);
+    const juce::String folder = SanctSoundClient::folderFromSetName(set);
+
+    std::cout << "[parser] ISO-Z    : " << (ok1 ? "OK" : "FAIL") << "\n";
+    std::cout << "[parser] short12  : " << (ok2 ? "OK" : "FAIL") << "\n";
+    std::cout << "[parser] folder   : " << folder << "\n";
+
+    if (!ok1 || !ok2 || folder.isEmpty())
+        return 2;
+
+    std::cout << "Self-test passed.\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a configurable SANCTSOUND_BUILD_CLI option and wire the new cli subdirectory into the JUCE build
- create a lightweight sanctsound_cli console target that exercises filename parsing without GUI dependencies
- expose and harden the shared parsing helpers in SanctSoundClient for both GUI and CLI use, including portable UTC handling

## Testing
- cmake -S juce_port -B build -DCMAKE_BUILD_TYPE=Release -DSANCTSOUND_BUILD_CLI=ON -DSANCTSOUND_HEADLESS=ON
- cmake --build build --target sanctsound_cli -j
- ./build/cli/sanctsound_cli_artefacts/Release/sanctsound_cli


------
https://chatgpt.com/codex/tasks/task_e_68d44a9c1db0833289d75a7f3c2ba810