### PR TITLE
Fix log window crash and improve event CSV parsing

### DIFF
--- a/juce_port/Source/MainComponent.h
+++ b/juce_port/Source/MainComponent.h
@@ -86,7 +86,7 @@ private:
     juce::Label selectionLabel;
 
     std::unique_ptr<juce::DocumentWindow> logWindow;
-    std::unique_ptr<juce::TextEditor> logText;
+    juce::TextEditor logText;
 
     std::vector<GroupEntry> groups;
     std::vector<FileEntry> files;

--- a/juce_port/Source/SanctSoundClient.h
+++ b/juce_port/Source/SanctSoundClient.h
@@ -40,6 +40,12 @@ public:
         std::vector<AudioSpan> spans;
     };
 
+    struct EventWindow
+    {
+        juce::Time startUTC;
+        juce::Time endUTC;
+    };
+
     SanctSoundClient();
 
     bool setDestinationDirectory(const juce::File& directory);
@@ -83,11 +89,12 @@ public:
         or empty string if no match. */
     static juce::String folderFromSetName(const juce::String& setName);
 
+    static bool parseEventsFromCsv(const juce::File& csvFile, juce::Array<EventWindow>& out);
+
     friend struct AudioHourSorter;
 
 private:
     static bool parseTimeUTC(const juce::String& text, juce::Time& out);
-    static std::vector<std::pair<juce::Time, juce::Time>> parseEventsFromCsv(const juce::File& localCsv);
     static std::vector<juce::Time> parsePresenceHoursFromCsv(const juce::File& localCsv);
     static std::vector<juce::Time> parsePresenceDaysFromCsv(const juce::File& localCsv);
     struct AudioHour


### PR DESCRIPTION
## Summary
- lazily create the Log window, reuse a shared TextEditor, and guard log writes so the button no longer crashes the GUI
- channel background logs through a shared helper lambda so gsutil/preview output is streamed into the window and debug log
- port the Python event CSV parsing logic (ISO/plain timestamps, fallback durations, dedupe) and refresh preview summaries to show mode, event count, and unique files

## Testing
- cmake -S juce_port -B build -DCMAKE_BUILD_TYPE=Release -DSANCTSOUND_BUILD_CLI=ON -DSANCTSOUND_HEADLESS=ON
- cmake --build build --target SanctSoundCli -j
- ./build/SanctSoundCli

------
https://chatgpt.com/codex/tasks/task_e_68d4509bfc8c8332a4b5ce22897e8d4d