### PR TITLE
Fix log window implementation

### DIFF
--- a/juce_port/Source/MainComponent.h
+++ b/juce_port/Source/MainComponent.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <juce_gui_extra/juce_gui_extra.h>
+#include <functional>
 #include <map>
 #include <vector>
 


### PR DESCRIPTION
## Summary
- update MainComponent header to store the log window and text editor members
- reimplement the log window using dedicated wrapper/document window classes and guard log appends

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d457890e94833285b6e0d1cc812f61