### PR TITLE
Adjust TextEditor scrollbar and font usage

### DIFF
--- a/juce_port/Source/MainComponent.cpp
+++ b/juce_port/Source/MainComponent.cpp
@@ -697,8 +697,12 @@ void MainComponent::toggleLogWindow()
     {
         logText.setMultiLine(true);
         logText.setReadOnly(true);
-        logText.setScrollbarsShown(true, true);
+        logText.setScrollbarsShown(true);
+#if JUCE_MAJOR_VERSION >= 8
+        logText.setFont(juce::Font(juce::FontOptions(13.0f)));
+#else
         logText.setFont(juce::Font(13.0f));
+#endif
 
         auto* wrapper = new LogWrapper(logText);
 


### PR DESCRIPTION
## Summary
- switch the log text editor to use the single-argument TextEditor::setScrollbarsShown API
- guard the log text editor font assignment to silence JUCE 8 deprecation warnings

## Testing
- cmake --build build --config Release *(fails: /workspace/semi/build is not a directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d543a515348332a9e0e2bb30dd6c42