### PR TITLE
Add preview debug helpers inside SanctSoundClient

### DIFF
--- a/juce_port/Source/SanctSoundClient.h
+++ b/juce_port/Source/SanctSoundClient.h
@@ -132,6 +132,11 @@ private:
                                        juce::StringArray& outNames,
                                        juce::Array<NeededFileRow>& rows,
                                        int& unmatchedCount);
+
+    juce::File makePreviewDebugDir (const juce::File& destDir, const juce::String& setName) const;
+    juce::StringArray rowsToUrls (const juce::Array<AudioHour>& rows) const;
+    static void dumpLines (const juce::File& outFile, const juce::StringArray& lines);
+
     static int runAndStream(const juce::StringArray& args,
                             const std::function<void(const juce::String&)>& log);
 


### PR DESCRIPTION
## Summary
- add private helper methods on SanctSoundClient for preview debug directories and logging
- write preview candidate and filtered URL dumps using the new helpers and keep encapsulation of AudioHour

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release *(fails: missing Xrandr headers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d56cfbe2cc83328fab7be5d090c406