### PR TITLE
Fix AudioHour sorter access

### DIFF
--- a/juce_port/Source/SanctSoundClient.cpp
+++ b/juce_port/Source/SanctSoundClient.cpp
@@ -1051,16 +1051,13 @@ static juce::StringArray runAndCollect(const juce::StringArray& cmd, int& exitCo
     return lines;
 }
 
-struct AudioHourSorter
+int SanctSoundClient::AudioHourSorter::compareElements(const AudioHour& a, const AudioHour& b) const
 {
-    int compareElements(const SanctSoundClient::AudioHour& a, const SanctSoundClient::AudioHour& b) const
-    {
-        auto diff = a.start.toMilliseconds() - b.start.toMilliseconds();
-        if (diff < 0) return -1;
-        if (diff > 0) return 1;
-        return a.folder.compareIgnoreCase(b.folder);
-    }
-};
+    auto diff = a.start.toMilliseconds() - b.start.toMilliseconds();
+    if (diff < 0) return -1;
+    if (diff > 0) return 1;
+    return a.folder.compareIgnoreCase(b.folder);
+}
 
 bool SanctSoundClient::parseTimeUTC(const juce::String& text, juce::Time& out)
 {

--- a/juce_port/Source/SanctSoundClient.h
+++ b/juce_port/Source/SanctSoundClient.h
@@ -91,8 +91,6 @@ public:
 
     static bool parseEventsFromCsv(const juce::File& csvFile, juce::Array<EventWindow>& out);
 
-    friend struct AudioHourSorter;
-
 private:
     static bool parseTimeUTC(const juce::String& text, juce::Time& out);
     static std::vector<juce::Time> parsePresenceHoursFromCsv(const juce::File& localCsv);
@@ -104,6 +102,11 @@ private:
         juce::Time start;
         juce::Time end;
         juce::String folder;
+    };
+
+    struct AudioHourSorter
+    {
+        int compareElements(const AudioHour& a, const AudioHour& b) const;
     };
 
     juce::StringArray listDeploymentsForSite(const juce::String& site,


### PR DESCRIPTION
## Summary
- move the AudioHour sorter into SanctSoundClient so it can access the nested type without violating access rules
- provide an out-of-class definition for the comparator function used when ordering audio hours

## Testing
- not run (requires JUCE build environment)


------
https://chatgpt.com/codex/tasks/task_e_68d57003ef788332bfd754fcb784a9d1